### PR TITLE
Fixed default return value

### DIFF
--- a/when-last-login.php
+++ b/when-last-login.php
@@ -160,6 +160,7 @@ class When_Last_Login {
 
         }
       }
+      return $value;
      }
 
      public static function column_sortable( $columns ){


### PR DESCRIPTION
Return the original value of the custom column if not the
‘when_lost_login’ column.

This breaks other plugins that hook into ‘manage_users_custom_column’ and depending on the priority prevents their column having data or the ‘when_lost_login’ column.