### PR TITLE
Feature: Add Last Login to PMPro CSV Export

### DIFF
--- a/when-last-login.php
+++ b/when-last-login.php
@@ -55,9 +55,10 @@ class When_Last_Login {
       add_action( 'pre_get_users', array( $this, 'sort_by_login_date') );
 
       //Integration for Paid Memberships Pro
-      //TODO: Improve integration with Member List and Paid Memberships Pro
       add_action( 'pmpro_memberslist_extra_cols_header', array( $this, 'pmpro_memberlist_add_header' ) );
       add_action( 'pmpro_memberslist_extra_cols_body', array( $this, 'pmpro_memberlist_add_column_data' ) );
+      add_filter( 'pmpro_memberslist_csv_extra_columns', array( $this, 'pmpro_csv_export_columns' ) );
+      add_filter( 'pmpro_memberslist_csv_extra_column_data', array( $this, 'pmpro_csv_export_row' ), 10, 2 );
       add_action( 'init', array( $this, 'login_record_cp' ) );
 
       add_action( 'admin_menu', array( $this, 'wll_settings_page' ), 9 );
@@ -142,7 +143,7 @@ class When_Last_Login {
 
     public function wll_hide_subscription_notice(){
     if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'wll_hide_notice_nonce' ) ) {
-        wp_die( __( 'Nonce is invalid', 'pmpro-pdf-invoices' ) );
+        wp_die( __( 'Nonce is invalid', 'when-last-login' ) );
       }
       update_option( 'wll_notice_hide', '1' );
     }
@@ -530,6 +531,40 @@ class When_Last_Login {
       </td>
 <?php
      }
+
+    /**
+     * Add Last Login column to PMPro CSV export.
+     *
+     * @param array $columns Array of column key => label pairs.
+     * @return array Modified columns array.
+     */
+    public static function pmpro_csv_export_columns( $columns ) {
+        if ( ! defined( 'PMPRO_VERSION' ) ) {
+            return $columns;
+        }
+        $columns['when_last_login'] = __( 'Last Login', 'when-last-login' );
+        return $columns;
+    }
+
+    /**
+     * Add Last Login data to PMPro CSV export rows.
+     *
+     * @param array $row The CSV row data.
+     * @param object $user The user object.
+     * @return array Modified row data.
+     */
+    public static function pmpro_csv_export_row( $row, $user ) {
+        if ( ! defined( 'PMPRO_VERSION' ) ) {
+            return $row;
+        }
+        $last_login = get_user_meta( $user->ID, 'when_last_login', true );
+        if ( ! empty( $last_login ) ) {
+            $row['when_last_login'] = date( 'Y-m-d H:i:s', $last_login );
+        } else {
+            $row['when_last_login'] = __( 'Never', 'when-last-login' );
+        }
+        return $row;
+    }
 
     public function wll_settings_page(){
 


### PR DESCRIPTION
## Summary

Implements feature request #43 - adds "Last Login" column to Paid Memberships Pro member CSV exports.

## Related Issue

Fixes #43

## Changes Made

- Added `pmpro_memberslist_csv_extra_columns` filter to include "Last Login" column header in CSV exports
- Added `pmpro_memberslist_csv_extra_column_data` filter to populate the Last Login data for each user row
- Last Login is exported as `Y-m-d H:i:s` format for readability
- Bonus: Fixed text domain typo (`pmpro-pdf-invoices` → `when-last-login`) in nonce error message
- Removed outdated TODO comment (we're now improving the integration)

## Testing Instructions

1. Install Paid Memberships Pro
2. Navigate to Memberships → Members List
3. Export members to CSV
4. Verify "Last Login" column is present with timestamps
5. Verify users who never logged in show "Never"

## Technical Notes

- Uses existing `when_last_login` user meta stored by the plugin
- Formats timestamp using `date()` for consistent CSV output
- Safe guards against missing PMPro (checks `PMPRO_VERSION` constant)

🤖 PR created by K2SO