### PR TITLE
Fix: Clean up migrated wll_records posts after database migration

### DIFF
--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -593,6 +593,9 @@ class WLL_DB {
 			$status['status']    = 'complete';
 			$status['completed'] = current_time( 'mysql' );
 			update_option( 'wll_migration_status', $status );
+
+			// Clean up migrated posts from the posts table.
+			self::cleanup_migrated_posts();
 		}
 	}
 

--- a/includes/updates/upgrade-1.3.0.php
+++ b/includes/updates/upgrade-1.3.0.php
@@ -265,6 +265,11 @@ function wll_migrate_records_batch() {
 		$status['status']    = 'complete';
 		$status['completed'] = current_time( 'mysql' );
 		update_option( 'wll_migration_status', $status );
+
+		// Clean up migrated posts from the posts table.
+		if ( class_exists( 'WLL_DB' ) ) {
+			WLL_DB::cleanup_migrated_posts();
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

The 1.3.0 migration from custom post type (`wll_records`) to dedicated database tables was leaving old posts in the `wp_posts` table after migration completed. This clutters up the posts table unnecessarily.

## Problem

When the migration finishes:
1. The `wll_migration_status` option is set to `complete`
2. But the `wll_records` posts remain in the database
3. The `cleanup_migrated_posts()` method exists but was never called

## Solution

Call `cleanup_migrated_posts()` when migration status is set to complete. This method:
- Deletes all posts with `post_type = 'wll_records'
- Deletes associated postmeta via LEFT JOIN
- Fires the `wll_cleanup_migrated_posts` action hook

## Changes Made

- Added cleanup call in `WLL_DB::migrate_batch()` (class-wll-db.php)
- Added cleanup call in `wll_migrate_records_batch()` (upgrade-1.3.0.php)
- Both locations only run cleanup after migration status is `complete`

## Testing Instructions

1. Install plugin on a site with existing `wll_records` posts
2. Trigger the 1.3.0 database migration
3. Verify migration completes successfully
4. Check that `wll_records` posts are removed from `wp_posts`
5. Check that associated postmeta is also removed

## Code Standards

- Follows WPCS (spaces inside parens, Yoda conditions)
- Uses existing class method with proper error handling
- Maintains backward compatibility

🤖 PR created by K2SO