### PR TITLE
Fix list table bulk delete and form handling

### DIFF
--- a/includes/class-wll-list-table.php
+++ b/includes/class-wll-list-table.php
@@ -171,10 +171,12 @@ class WLL_List_Table extends WP_List_Table {
 	 * Process bulk actions.
 	 *
 	 * @since  1.3.0
+	 *
+	 * @return int Number of records deleted.
 	 */
 	public function process_bulk_action() {
 		if ( 'delete' === $this->current_action() ) {
-			$nonce = isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '';
+			$nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( $_REQUEST['_wpnonce'] ) : '';
 
 			if ( ! wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
 				wp_die( esc_html__( 'Invalid nonce', 'when-last-login' ) );
@@ -183,9 +185,11 @@ class WLL_List_Table extends WP_List_Table {
 			$record_ids = isset( $_REQUEST['record_id'] ) ? array_map( 'intval', $_REQUEST['record_id'] ) : array();
 
 			if ( ! empty( $record_ids ) ) {
-				WLL_DB::delete_records( $record_ids );
+				return WLL_DB::delete_records( $record_ids );
 			}
 		}
+
+		return 0;
 	}
 
 	/**

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -547,7 +547,16 @@ class When_Last_Login {
      * @since  1.3.0
      */
     public function wll_login_records_callback() {
-      // Handle bulk delete redirect.
+      // Process bulk actions and redirect if needed.
+      $list_table = new WLL_List_Table();
+      $deleted = $list_table->process_bulk_action();
+
+      if ( $deleted > 0 ) {
+        wp_safe_redirect( add_query_arg( 'deleted', $deleted, admin_url( 'admin.php?page=wll-login-records' ) ) );
+        exit;
+      }
+
+      // Display success notice after redirect.
       if ( ! empty( $_REQUEST['deleted'] ) ) {
         printf(
           '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
@@ -559,16 +568,15 @@ class When_Last_Login {
         );
       }
 
+      $list_table->prepare_items();
+
       ?>
       <div class="wrap">
         <h1><?php esc_html_e( 'Login Records', 'when-last-login' ); ?></h1>
+        <?php $list_table->search_box( __( 'Search', 'when-last-login' ), 'wll-records' ); ?>
         <form method="post">
-          <?php
-          $list_table = new WLL_List_Table();
-          $list_table->prepare_items();
-          $list_table->search_box( __( 'Search', 'when-last-login' ), 'wll-records' );
-          $list_table->display();
-          ?>
+          <input type="hidden" name="page" value="<?php echo esc_attr( $_REQUEST['page'] ); ?>" />
+          <?php $list_table->display(); ?>
         </form>
       </div>
       <?php


### PR DESCRIPTION
## Summary

Fixes issues with the WP List Table bulk delete functionality.

## Changes

1. **Bulk delete now shows success message**
   - `process_bulk_action()` returns count of deleted records
   - Redirects with `?deleted=N` query param
   - Shows "N records deleted" notice after redirect

2. **Form structure improved**
   - Search box moved outside form (standard WordPress pattern)
   - Hidden `page` field added for proper context

3. **Nonce sanitization**
   - Added `sanitize_text_field()` to nonce handling

## Testing

1. Go to When Last Login → Login Records
2. Select some records with checkboxes
3. Choose "Delete" from bulk actions
4. Apply - should redirect and show "N records deleted" notice

🤖 PR created by K2SO