### PR TITLE
Fix: User search not showing users who never logged in

### DIFF
--- a/when-last-login.php
+++ b/when-last-login.php
@@ -483,8 +483,11 @@ class When_Last_Login {
 
     public static function sort_by_login_date( $query ) {
       if ( 'when_last_login' == $query->get( 'orderby' ) ) {
-        $query->set( 'orderby', 'meta_value_num' );
-        $query->set( 'meta_key', 'when_last_login' );
+        // Skip sorting during search to avoid filtering out users without login meta.
+        if ( ! is_admin() || ! isset( $_GET['s'] ) || empty( $_GET['s'] ) ) {
+          $query->set( 'orderby', 'meta_value_num' );
+          $query->set( 'meta_key', 'when_last_login' );
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

Fixes a bug where users who have never logged in do not appear in Users > All Users search results.

## Related Issue

https://wordpress.org/support/topic/bug-user-search-not-working-users-who-never-logged-in-dont-appear/

## Changes Made

- Modified `sort_by_login_date()` to skip the `meta_key` filter during active searches
- Added check for `$_GET["s"]` to detect when a search is being performed
- Users without `when_last_login` meta are no longer excluded from search results

## Root Cause

The `sort_by_login_date()` method hooks into `pre_get_users` and sets `meta_key = "when_last_login"`. This causes WordPress to filter out any users who don't have this meta key — i.e., users who have never logged in.

## Testing Instructions

1. Create a new user (e.g., subscriber role)
2. Ensure they've never logged in
3. Go to **Users > All Users**
4. Search for the user by username or email
5. **Before fix:** User does not appear in results
6. **After fix:** User appears in results

## Additional Notes

The fix only applies the meta sort when:
- Not in admin area, OR
- No search term is present (`$_GET["s"]` is empty/not set)

This preserves the Last Login column sorting functionality while allowing all users to be found via search.

🤖 PR created by K2SO