### PR TITLE
Security: Add output escaping for PMPro integration and multisite widget

### DIFF
--- a/when-last-login.php
+++ b/when-last-login.php
@@ -339,10 +339,10 @@ class When_Last_Login {
                         $count = 1;
                         
                         foreach($topusers as $wllusers){
-                            echo '<tr><td>' . intval( $count ) . '</td>';
+                            echo '<tr><td>' . esc_html( intval( $count ) ) . '</td>';
                             echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
-                            echo '<td>' . get_user_meta( $wllusers->ID, 'when_last_login_count', true ) . '</td>';
-                            echo '<td>' . date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
+                            echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
+                            echo '<td>' . esc_html( date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) ) . '</td></tr>';
                             $count++;
                         }
                       
@@ -362,9 +362,9 @@ class When_Last_Login {
                 $wll_widget_settings = get_option( 'wll_settings' );
                 $wll_widget_track_all = ! isset( $wll_widget_settings['track_all_records'] ) || intval( $wll_widget_settings['track_all_records'] ) === 1;
                 ?>
-                <a href="<?php echo admin_url( 'users.php?orderby=when_last_login&order=desc' ); ?>"><?php _e( 'View All Users', 'when-last-login' ); ?></a>
+                <a href="<?php echo esc_url( admin_url( 'users.php?orderby=when_last_login&order=desc' ) ); ?>"><?php _e( 'View All Users', 'when-last-login' ); ?></a>
                 <?php if ( $wll_widget_track_all ) : ?>
-                | <a href="<?php echo admin_url( 'admin.php?page=wll-login-records' ); ?>"><?php _e( 'View Login Records', 'when-last-login' ); ?></a>
+                | <a href="<?php echo esc_url( admin_url( 'admin.php?page=wll-login-records' ) ); ?>"><?php _e( 'View Login Records', 'when-last-login' ); ?></a>
                 <?php endif; ?>
                 <?php
 
@@ -393,10 +393,10 @@ class When_Last_Login {
                 $count = 1;
                 
                 foreach($topusers as $wllusers){
-                    echo '<tr><td>' . intval( $count ) . '</td>';
-                    echo '<td>' . $wllusers->display_name . '</td>';
-                    echo '<td>' . get_user_meta( $wllusers->ID, 'when_last_login_count', true ) . '</td>';
-                    echo '<td>' . date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
+                    echo '<tr><td>' . esc_html( intval( $count ) ) . '</td>';
+                    echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
+                    echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
+                    echo '<td>' . esc_html( date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) ) . '</td></tr>';
                     $count++;
                 }
               
@@ -507,9 +507,9 @@ class When_Last_Login {
       <td>
 <?php
       if( ! empty( $users->when_last_login ) ){
-        echo human_time_diff( $users->when_last_login );
+        echo esc_html( human_time_diff( $users->when_last_login ) );
       }else{
-        return esc_html_e( 'Never', 'when-last-login' );
+        echo esc_html_e( 'Never', 'when-last-login' );
       }
 ?>
       </td>


### PR DESCRIPTION
## Summary

This PR addresses output escaping vulnerabilities identified in the security review.

## Changes

- **PMPro Integration**: Added `esc_html()` around `human_time_diff()` output in `pmpro_memberlist_add_column_data()` to prevent XSS
- **PMPro Consistency**: Changed `return` to `echo` for consistent output handling in PMPro column data
- **Multisite Widget**: Added `esc_url()` around `admin_url()` calls in multisite dashboard widget links

## Security Impact

All dynamic output is now properly escaped:
- User-generated content escaped with `esc_html()`
- URLs escaped with `esc_url()`
- Prevents potential XSS vulnerabilities in dashboard widgets and PMPro integration

## Testing

Tested output escaping in:
- Multisite dashboard widget (all sites loop)
- PMPro member list column display
- Both logged-in and non-logged-in states