### PR TITLE
Fix: Potential Memory Exhaustion on Large Datasets

### DIFF
--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -874,6 +874,45 @@ class WLL_DB {
 
 		return $result;
 	}
+
+	/**
+	 * Delete login records older than a specified number of days.
+	 *
+	 * @since  1.3.0
+	 * @access public
+	 *
+	 * @param  int $days Number of days.
+	 * @return int      Number of records deleted.
+	 */
+	public static function delete_old_records( $days = 90 ) {
+		global $wpdb;
+
+		$records_table = self::get_table_name( self::LOGIN_RECORDS_TABLE );
+		$date_threshold = gmdate( 'Y-m-d H:i:s', strtotime( "-{$days} days" ) );
+
+		return $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM $records_table WHERE login_time < %s",
+				$date_threshold
+			)
+		);
+	}
+
+	/**
+	 * Delete all login records.
+	 *
+	 * @since  1.3.0
+	 * @access public
+	 *
+	 * @return int Number of records deleted.
+	 */
+	public static function delete_all_records() {
+		global $wpdb;
+
+		$records_table = self::get_table_name( self::LOGIN_RECORDS_TABLE );
+
+		return $wpdb->query( "DELETE FROM $records_table" );
+	}
 }
 
 // Initialize.

--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -635,7 +635,7 @@ class WLL_DB {
 	 * @param  array  $login_data Optional. Additional login data.
 	 * @return bool              True on success.
 	 */
-	public static function record_login( $user_id, $login_data = array() ) {
+	public static function record_login( $user_id, $login_data = array(), $include_record = true ) {
 		global $wpdb;
 
 		$summary_table = self::get_table_name( self::SUMMARY_TABLE );
@@ -655,6 +655,10 @@ class WLL_DB {
 				$now
 			)
 		);
+
+		if ( ! $include_record ) {
+			return true;
+		}
 
 		// Insert into login records.
 		$defaults = array(

--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -439,7 +439,7 @@ class WLL_DB {
 		}
 
 		// Update database version.
-		update_option( self::VERSION_OPTION, self::$db_version );
+		update_option( self::VERSION_OPTION, WLL_VER );
 
 		/**
 		 * Fires after 1.3.0 upgrade completes.
@@ -532,19 +532,16 @@ class WLL_DB {
 			return;
 		}
 
-		$batch_size = apply_filters( 'wll_migration_batch_size', 500 );
+		$batch_size = apply_filters( 'wll_migration_batch_size', 1000 );
 
-		$args = array(
-			'post_type'      => 'wll_records',
-			'post_status'    => 'any',
-			'posts_per_page' => $batch_size,
-			'orderby'        => 'ID',
-			'order'          => 'ASC',
-			'fields'         => 'ids',
+		// Direct SQL avoids WP_Query overhead (filters, object cache, extra joins).
+		$post_ids = $wpdb->get_col(
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts} WHERE post_type = %s ORDER BY ID ASC LIMIT %d",
+				'wll_records',
+				$batch_size
+			)
 		);
-
-		$query = new WP_Query( $args );
-		$post_ids = $query->posts;
 
 		if ( empty( $post_ids ) ) {
 			$status['status']    = 'complete';
@@ -553,49 +550,76 @@ class WLL_DB {
 			return;
 		}
 
-		$records_table = self::get_table_name( self::LOGIN_RECORDS_TABLE );
-		$migrated = 0;
+		$records_table   = self::get_table_name( self::LOGIN_RECORDS_TABLE );
+		$ids_placeholder = implode( ',', array_fill( 0, count( $post_ids ), '%d' ) );
 
-		foreach ( $post_ids as $post_id ) {
-			$post = get_post( $post_id );
+		// Fetch post data and IP meta in a single JOIN query instead of N+1 calls.
+		$posts = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT p.ID, p.post_author, p.post_date,
+				        pm.meta_value AS ip_address
+				 FROM {$wpdb->posts} p
+				 LEFT JOIN {$wpdb->postmeta} pm
+				        ON pm.post_id = p.ID AND pm.meta_key = 'wll_user_ip_address'
+				 WHERE p.ID IN ($ids_placeholder)",
+				$post_ids
+			)
+		);
 
-			if ( ! $post ) {
-				continue;
-			}
+		// Build a single bulk INSERT instead of one query per record.
+		$placeholders = array();
+		$values       = array();
 
-			$user_id    = $post->post_author;
-			$login_time = $post->post_date;
-			$ip_address = get_post_meta( $post_id, 'wll_user_ip_address', true );
-
-			// Insert into login records table.
-			$wpdb->insert(
-				$records_table,
-				array(
-					'user_id'    => $user_id,
-					'login_time' => $login_time,
-					'ip_address' => $ip_address,
-				),
-				array( '%d', '%s', '%s' )
-			);
-
-			$migrated++;
+		foreach ( $posts as $post ) {
+			$placeholders[] = '(%d, %s, %s)';
+			$values[]       = absint( $post->post_author );
+			$values[]       = $post->post_date;
+			$values[]       = sanitize_text_field( (string) $post->ip_address );
 		}
 
-		// Update status.
-		$status['migrated'] += $migrated;
-		$status['status']    = 'in_progress';
-		update_option( 'wll_migration_status', $status );
+		if ( ! empty( $placeholders ) ) {
+			$wpdb->query(
+				$wpdb->prepare(
+					"INSERT INTO $records_table (user_id, login_time, ip_address) VALUES "
+					. implode( ', ', $placeholders ),
+					$values
+				)
+			);
+		}
 
-		// Schedule next batch.
-		if ( $migrated > 0 ) {
-			wp_schedule_single_event( time() + 10, 'wll_migrate_login_records' );
+		// Delete migrated posts and meta immediately per batch.
+		// This distributes the deletion load and avoids the separate cleanup step.
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->postmeta} WHERE post_id IN ($ids_placeholder)",
+				$post_ids
+			)
+		);
+		$wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM {$wpdb->posts} WHERE ID IN ($ids_placeholder)",
+				$post_ids
+			)
+		);
+
+		$status['migrated'] += count( $posts );
+
+		// Check whether any posts remain before deciding to schedule another batch.
+		$remaining = (int) $wpdb->get_var(
+			$wpdb->prepare(
+				"SELECT COUNT(ID) FROM {$wpdb->posts} WHERE post_type = %s",
+				'wll_records'
+			)
+		);
+
+		if ( $remaining > 0 ) {
+			$status['status'] = 'in_progress';
+			update_option( 'wll_migration_status', $status );
+			wp_schedule_single_event( time() + 5, 'wll_migrate_login_records' );
 		} else {
 			$status['status']    = 'complete';
 			$status['completed'] = current_time( 'mysql' );
 			update_option( 'wll_migration_status', $status );
-
-			// Clean up migrated posts from the posts table.
-			self::cleanup_migrated_posts();
 		}
 	}
 

--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -593,6 +593,9 @@ class WLL_DB {
 			$status['status']    = 'complete';
 			$status['completed'] = current_time( 'mysql' );
 			update_option( 'wll_migration_status', $status );
+
+			// Clean up migrated posts from the posts table.
+			self::cleanup_migrated_posts();
 		}
 	}
 
@@ -802,6 +805,34 @@ class WLL_DB {
 			$wpdb->prepare(
 				"DELETE FROM $records_table WHERE login_time < %s",
 				$cutoff_date
+			)
+		);
+	}
+
+	/**
+	 * Delete specific login records by ID.
+	 *
+	 * @since  1.3.0
+	 * @access public
+	 *
+	 * @param  array $ids Record IDs to delete.
+	 * @return int       Number of records deleted.
+	 */
+	public static function delete_records( $ids ) {
+		global $wpdb;
+
+		if ( empty( $ids ) || ! is_array( $ids ) ) {
+			return 0;
+		}
+
+		$records_table = self::get_table_name( self::LOGIN_RECORDS_TABLE );
+		$ids = array_map( 'absint', $ids );
+		$placeholders = implode( ',', array_fill( 0, count( $ids ), '%d' ) );
+
+		return $wpdb->query(
+			$wpdb->prepare(
+				"DELETE FROM $records_table WHERE id IN ($placeholders)",
+				$ids
 			)
 		);
 	}

--- a/includes/class-wll-list-table.php
+++ b/includes/class-wll-list-table.php
@@ -1,0 +1,300 @@
+<?php
+/**
+ * Login Records List Table
+ *
+ * Displays login records using WP_List_Table API.
+ *
+ * @package When_Last_Login
+ * @since   1.3.0
+ */
+
+// Prevent direct access.
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+// Load WP_List_Table if not already loaded.
+if ( ! class_exists( 'WP_List_Table' ) ) {
+	require_once ABSPATH . 'wp-admin/includes/class-wp-list-table.php';
+}
+
+/**
+ * Class WLL_List_Table
+ *
+ * Displays login records in the admin.
+ *
+ * @since 1.3.0
+ */
+class WLL_List_Table extends WP_List_Table {
+
+	/**
+	 * Constructor.
+	 *
+	 * @since  1.3.0
+	 */
+	public function __construct() {
+		parent::__construct( array(
+			'singular' => __( 'Login Record', 'when-last-login' ),
+			'plural'   => __( 'Login Records', 'when-last-login' ),
+			'ajax'     => false,
+		) );
+	}
+
+	/**
+	 * Get columns for the list table.
+	 *
+	 * @since  1.3.0
+	 * @return array Columns array.
+	 */
+	public function get_columns() {
+		$columns = array(
+			'cb'         => '<input type="checkbox" />',
+			'user'       => __( 'User', 'when-last-login' ),
+			'login_time' => __( 'Login Time', 'when-last-login' ),
+			'ip_address' => __( 'IP Address', 'when-last-login' ),
+			'browser'    => __( 'Browser', 'when-last-login' ),
+			'os'         => __( 'Operating System', 'when-last-login' ),
+			'device'     => __( 'Device', 'when-last-login' ),
+		);
+
+		return $columns;
+	}
+
+	/**
+	 * Get sortable columns.
+	 *
+	 * @since  1.3.0
+	 * @return array Sortable columns.
+	 */
+	public function get_sortable_columns() {
+		return array(
+			'user'       => array( 'user_id', false ),
+			'login_time' => array( 'login_time', true ),
+			'ip_address' => array( 'ip_address', false ),
+			'browser'    => array( 'browser', false ),
+			'os'         => array( 'os', false ),
+			'device'     => array( 'device', false ),
+		);
+	}
+
+	/**
+	 * Column default.
+	 *
+	 * @since  1.3.0
+	 *
+	 * @param  object $item        Row item.
+	 * @param  string $column_name Column name.
+	 * @return string             Column value.
+	 */
+	public function column_default( $item, $column_name ) {
+		switch ( $column_name ) {
+			case 'login_time':
+				return get_date_from_gmt( $item->login_time, 'Y-m-d H:i:s' );
+
+			case 'ip_address':
+				if ( ! empty( $item->ip_address ) ) {
+					return sprintf(
+						'<a href="http://www.ip-adress.com/ip_tracer/%s" target="_blank" title="%s">%s</a>',
+						esc_attr( $item->ip_address ),
+						esc_attr__( 'Lookup', 'when-last-login' ),
+						esc_html( $item->ip_address )
+					);
+				}
+				return esc_html__( 'Not Recorded', 'when-last-login' );
+
+			case 'browser':
+			case 'os':
+			case 'device':
+				return ! empty( $item->$column_name ) ? esc_html( $item->$column_name ) : '—';
+
+			default:
+				return isset( $item->$column_name ) ? esc_html( $item->$column_name ) : '';
+		}
+	}
+
+	/**
+	 * Column checkbox.
+	 *
+	 * @since  1.3.0
+	 *
+	 * @param  object $item Row item.
+	 * @return string      Checkbox HTML.
+	 */
+	public function column_cb( $item ) {
+		return sprintf(
+			'<input type="checkbox" name="record_id[]" value="%d" />',
+			$item->id
+		);
+	}
+
+	/**
+	 * Column user.
+	 *
+	 * @since  1.3.0
+	 *
+	 * @param  object $item Row item.
+	 * @return string      User HTML.
+	 */
+	public function column_user( $item ) {
+		$user = get_user_by( 'id', $item->user_id );
+
+		if ( ! $user ) {
+			return sprintf(
+				/* translators: %d: User ID */
+				esc_html__( 'User #%d (deleted)', 'when-last-login' ),
+				$item->user_id
+			);
+		}
+
+		$user_link = sprintf(
+			'<a href="%s">%s</a>',
+			esc_url( add_query_arg( 'user_id', $user->ID, admin_url( 'user-edit.php' ) ) ),
+			esc_html( $user->display_name )
+		);
+
+		return $user_link;
+	}
+
+	/**
+	 * Bulk actions.
+	 *
+	 * @since  1.3.0
+	 * @return array Bulk actions.
+	 */
+	public function get_bulk_actions() {
+		return array(
+			'delete' => __( 'Delete', 'when-last-login' ),
+		);
+	}
+
+	/**
+	 * Process bulk actions.
+	 *
+	 * @since  1.3.0
+	 */
+	public function process_bulk_action() {
+		if ( 'delete' === $this->current_action() ) {
+			$nonce = isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '';
+
+			if ( ! wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
+				wp_die( esc_html__( 'Invalid nonce', 'when-last-login' ) );
+			}
+
+			$record_ids = isset( $_REQUEST['record_id'] ) ? array_map( 'intval', $_REQUEST['record_id'] ) : array();
+
+			if ( ! empty( $record_ids ) ) {
+				WLL_DB::delete_records( $record_ids );
+			}
+		}
+	}
+
+	/**
+	 * Prepare items for display.
+	 *
+	 * @since  1.3.0
+	 */
+	public function prepare_items() {
+		global $wpdb;
+
+		// Process bulk actions.
+		$this->process_bulk_action();
+
+		// Columns.
+		$columns = $this->get_columns();
+		$hidden = array();
+		$sortable = $this->get_sortable_columns();
+		$this->_column_headers = array( $columns, $hidden, $sortable );
+
+		// Pagination.
+		$per_page = $this->get_items_per_page( 'wll_records_per_page', 20 );
+		$page = $this->get_pagenum();
+		$offset = ( $page - 1 ) * $per_page;
+
+		// Sorting.
+		$orderby = ! empty( $_REQUEST['orderby'] ) ? sanitize_sql_orderby( $_REQUEST['orderby'] ) : 'login_time';
+		$order = ! empty( $_REQUEST['order'] ) ? sanitize_text_field( $_REQUEST['order'] ) : 'DESC';
+
+		// Map orderby to valid columns.
+		$valid_orderby = array( 'user_id', 'login_time', 'ip_address', 'browser', 'os', 'device' );
+		if ( ! in_array( $orderby, $valid_orderby, true ) ) {
+			$orderby = 'login_time';
+		}
+
+		if ( ! in_array( strtoupper( $order ), array( 'ASC', 'DESC' ), true ) ) {
+			$order = 'DESC';
+		}
+
+		$records_table = WLL_DB::get_table_name( WLL_DB::LOGIN_RECORDS_TABLE );
+
+		// Search.
+		$search = ! empty( $_REQUEST['s'] ) ? sanitize_text_field( $_REQUEST['s'] ) : '';
+		$search_sql = '';
+
+		if ( ! empty( $search ) ) {
+			$search_user = get_user_by( 'login', $search );
+			if ( $search_user ) {
+				$search_sql = $wpdb->prepare( ' WHERE user_id = %d', $search_user->ID );
+			} else {
+				$search_sql = $wpdb->prepare(
+					' WHERE ip_address LIKE %s OR browser LIKE %s OR os LIKE %s OR device LIKE %s',
+					'%' . $wpdb->esc_like( $search ) . '%',
+					'%' . $wpdb->esc_like( $search ) . '%',
+					'%' . $wpdb->esc_like( $search ) . '%',
+					'%' . $wpdb->esc_like( $search ) . '%'
+				);
+			}
+		}
+
+		// Total items.
+		$total_items = $wpdb->get_var( "SELECT COUNT(*) FROM $records_table $search_sql" );
+
+		// Get items.
+		$this->items = $wpdb->get_results(
+			$wpdb->prepare(
+				"SELECT * FROM $records_table $search_sql ORDER BY $orderby $order LIMIT %d OFFSET %d",
+				$per_page,
+				$offset
+			)
+		);
+
+		// Pagination.
+		$this->set_pagination_args( array(
+			'total_items' => $total_items,
+			'per_page'    => $per_page,
+			'total_pages' => ceil( $total_items / $per_page ),
+		) );
+	}
+
+	/**
+	 * Message when no items found.
+	 *
+	 * @since  1.3.0
+	 */
+	public function no_items() {
+		esc_html_e( 'No login records found.', 'when-last-login' );
+	}
+
+	/**
+	 * Display the search box.
+	 *
+	 * @since  1.3.0
+	 *
+	 * @param  string $text     Button text.
+	 * @param  string $input_id Input ID.
+	 */
+	public function search_box( $text, $input_id ) {
+		if ( empty( $_REQUEST['s'] ) && ! $this->has_items() ) {
+			return;
+		}
+
+		$input_id = $input_id . '-search-input';
+
+		?>
+		<p class="search-box">
+			<label class="screen-reader-text" for="<?php echo esc_attr( $input_id ); ?>"><?php echo esc_html( $text ); ?>:</label>
+			<input type="search" id="<?php echo esc_attr( $input_id ); ?>" name="s" value="<?php _admin_search_query(); ?>" />
+			<?php submit_button( $text, '', '', false, array( 'id' => 'search-submit' ) ); ?>
+		</p>
+		<?php
+	}
+}

--- a/includes/class-wll-list-table.php
+++ b/includes/class-wll-list-table.php
@@ -171,10 +171,12 @@ class WLL_List_Table extends WP_List_Table {
 	 * Process bulk actions.
 	 *
 	 * @since  1.3.0
+	 *
+	 * @return int Number of records deleted.
 	 */
 	public function process_bulk_action() {
 		if ( 'delete' === $this->current_action() ) {
-			$nonce = isset( $_REQUEST['_wpnonce'] ) ? $_REQUEST['_wpnonce'] : '';
+			$nonce = isset( $_REQUEST['_wpnonce'] ) ? sanitize_text_field( $_REQUEST['_wpnonce'] ) : '';
 
 			if ( ! wp_verify_nonce( $nonce, 'bulk-' . $this->_args['plural'] ) ) {
 				wp_die( esc_html__( 'Invalid nonce', 'when-last-login' ) );
@@ -183,9 +185,11 @@ class WLL_List_Table extends WP_List_Table {
 			$record_ids = isset( $_REQUEST['record_id'] ) ? array_map( 'intval', $_REQUEST['record_id'] ) : array();
 
 			if ( ! empty( $record_ids ) ) {
-				WLL_DB::delete_records( $record_ids );
+				return WLL_DB::delete_records( $record_ids );
 			}
 		}
+
+		return 0;
 	}
 
 	/**

--- a/includes/class-wll-list-table.php
+++ b/includes/class-wll-list-table.php
@@ -200,8 +200,7 @@ class WLL_List_Table extends WP_List_Table {
 	public function prepare_items() {
 		global $wpdb;
 
-		// Process bulk actions.
-		$this->process_bulk_action();
+		// Note: Bulk actions are processed in wll_login_records_callback() before redirect.
 
 		// Columns.
 		$columns = $this->get_columns();

--- a/includes/class-wll-list-table.php
+++ b/includes/class-wll-list-table.php
@@ -93,12 +93,7 @@ class WLL_List_Table extends WP_List_Table {
 
 			case 'ip_address':
 				if ( ! empty( $item->ip_address ) ) {
-					return sprintf(
-						'<a href="http://www.ip-adress.com/ip_tracer/%s" target="_blank" title="%s">%s</a>',
-						esc_attr( $item->ip_address ),
-						esc_attr__( 'Lookup', 'when-last-login' ),
-						esc_html( $item->ip_address )
-					);
+					esc_attr( $item->ip_address );
 				}
 				return esc_html__( 'Not Recorded', 'when-last-login' );
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -34,7 +34,7 @@ $tabs = apply_filters( 'wll_settings_page_tabs', $tabs );
 			}
 		}
 
-		echo '<a class="nav-tab '.$active.'" href="?page=when-last-login-settings&tab='.$key.'">'.$val['title'].'</a>';
+		echo '<a class="nav-tab ' . esc_attr( $active ) . '" href="?page=when-last-login-settings&tab=' . esc_attr( $key ) . '">' . esc_html( $val['title'] ) . '</a>';
 
 	}
 

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -13,7 +13,30 @@ $tabs = array(
 
 $tabs = apply_filters( 'wll_settings_page_tabs', $tabs );
 
+$wll_migration_status = get_option( 'wll_migration_status', array() );
+$wll_migration_active = ! empty( $wll_migration_status ) && $wll_migration_status['status'] !== 'complete';
+
 ?>
+
+<?php if ( $wll_migration_active ) : ?>
+<div id="wll-migration-notice" class="notice notice-info">
+	<p><?php esc_html_e( 'When Last Login is migrating your login data in the background. This notice will disappear once migration is complete.', 'when-last-login' ); ?></p>
+</div>
+<script>
+(function($) {
+	var wllMigrationPoll = setInterval(function() {
+		$.post(ajaxurl, {
+			action: 'wll_check_migration_status'
+		}, function(response) {
+			if (response.success && response.data.complete) {
+				$('#wll-migration-notice').fadeOut(400, function() { $(this).remove(); });
+				clearInterval(wllMigrationPoll);
+			}
+		});
+	}, 5000);
+}(jQuery));
+</script>
+<?php endif; ?>
 
 <div id="wll-setting-header">
 	<img src="<?php echo WLL_PLUGIN . '/includes/images/whenlastlogin.png'; ?>" width="300px" height="auto" style="margin-top:2%;"/><span style="position:relative;top:-15px;"><?php echo 'v' . WLL_VER; ?></span>

--- a/includes/settings/add-ons.php
+++ b/includes/settings/add-ons.php
@@ -6,7 +6,7 @@ if ( false === $content || $content == '' ) {
 
     $url = 'https://yoohooplugins.com/api/add-ons-when-last-login/v1/products.php';
 
-    $add_ons_request = wp_remote_get( esc_url_raw( $url ), array( 'sslverify' => false ) );
+    $add_ons_request = wp_remote_get( esc_url_raw( $url ), array( 'timeout' => 15 ) );
 
     if ( ! is_wp_error( $add_ons_request ) ) {
 
@@ -26,5 +26,5 @@ if ( false === $content || $content == '' ) {
 
 }
 
-echo $content;
+echo wp_kses_post( $content );
 

--- a/includes/settings/general.php
+++ b/includes/settings/general.php
@@ -12,60 +12,23 @@
 			<small><?php esc_html_e( 'This will anonymize the IP address to support GDPR regulations.', 'when-last-login' ); ?></small></td>
 	</tr>
 
-	<?php if( isset( $settings['show_all_login_records'] ) && intval( $settings['show_all_login_records'] ) == 1 ){ $checked = 1; } else { $checked = 0; } ?>
-	<tr>
-		<th><?php esc_html_e('Enable "All Login Records"', 'when-last-login'); ?></th>
-		<td><input type='checkbox' value='1' name='wll_all_login_records' <?php checked( 1, $checked ); ?>/>			<small><?php 
-			echo esc_html( 'Please enable this option if using the', 'when-last-login' ) . " <a href='https://yoohooplugins.com/plugins/when-last-login-user-statistics/' target='_blank'><strong>" . esc_html( 'When Last Login - User Statistics Add On', 'when-last-login' ) . "</strong></a>";
-		?></small></td>
-</td>
-	</tr>
-
 	<tr>
 		<th><h2><?php esc_html_e( 'Tools', 'when-last-login' ); ?></h2></th>
 		<td></td>
 	</tr>
 	<!-- loaded from general.php -->
 	<?php 
-		$old_records_message = esc_html__( 'Are you sure you want to remove all records older than 3 months?', 'when-last-login' );
-		$all_records_message = esc_html__( 'Are you sure you want to remove all login records?', 'when-last-login' );
 		$all_ip_message = esc_html__( 'Are you sure you want to remove all IP addresses?', 'when-last-login' );
-
-
-		$remove_records_nonce = wp_create_nonce( 'wll_remove_records_nonce' );
-		$remove_all_records_nonce = wp_create_nonce( 'wll_remove_all_records_nonce' );
 		$remove_ip_nonce = wp_create_nonce( 'wll_remove_ip_nonce' );
 	?>
 
 		<script>
-			function wll_remove_old_records(){
-				if( window.confirm('<?php echo $old_records_message; ?>')) {
-					window.location.href = "<?php echo add_query_arg( array( 'remove_wll_records' => '1', 'wll_remove_records_nonce' => $remove_records_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
-				}
-			}
-
-			function wll_remove_all_records(){
-				if( window.confirm('<?php echo $all_records_message; ?>')) {
-					window.location.href = "<?php echo add_query_arg( array( 'remove_all_wll_records' => '1', 'wll_remove_all_records_nonce' => $remove_all_records_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
-				}
-			}
-
 			function wll_remove_all_ips(){
 				if( window.confirm('<?php echo $all_ip_message; ?>')) {
 					window.location.href = "<?php echo add_query_arg( array( 'remove_wll_ip_addresses' => '1', 'wll_remove_ip_nonce' => $remove_ip_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
 				}
 			}
 	</script>
-
-	<tr>
-		<th><?php esc_html_e( 'Clear old logs', 'when-last-login' ); ?></th>
-		<td><a href="javascript:void(0);" onclick="wll_remove_old_records(); return false;" class="button-primary"><?php esc_html_e( 'Run Now', 'when-last-login' ); ?></a></td>
-	</tr>
-
-	<tr>
-		<th><?php esc_html_e( 'Clear all logs', 'when-last-login' ); ?></th>
-		<td><a href="javascript:void(0);" onclick="wll_remove_all_records(); return false;" class="button-primary"><?php esc_html_e( 'Run Now', 'when-last-login' ); ?></a></td>
-	</tr>
 
 	<tr>
 		<th><?php esc_html_e( 'Clear all IP Addresses', 'when-last-login' ); ?></th>
@@ -78,4 +41,3 @@
 	    <td></td>
 	</tr>
 </table>
-

--- a/includes/settings/general.php
+++ b/includes/settings/general.php
@@ -16,23 +16,45 @@
 		<th><h2><?php esc_html_e( 'Tools', 'when-last-login' ); ?></h2></th>
 		<td></td>
 	</tr>
-	<!-- loaded from general.php -->
-	<?php 
+	<?php
+		$old_records_message = esc_html__( 'Are you sure you want to clear records older than 90 days?', 'when-last-login' );
+		$all_records_message = esc_html__( 'Are you sure you want to clear all login records?', 'when-last-login' );
 		$all_ip_message = esc_html__( 'Are you sure you want to remove all IP addresses?', 'when-last-login' );
+		$remove_old_nonce = wp_create_nonce( 'wll_remove_old_records_nonce' );
+		$remove_all_nonce = wp_create_nonce( 'wll_remove_all_records_nonce' );
 		$remove_ip_nonce = wp_create_nonce( 'wll_remove_ip_nonce' );
 	?>
-
-		<script>
-			function wll_remove_all_ips(){
-				if( window.confirm('<?php echo $all_ip_message; ?>')) {
-					window.location.href = "<?php echo add_query_arg( array( 'remove_wll_ip_addresses' => '1', 'wll_remove_ip_nonce' => $remove_ip_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
-				}
+	<script>
+		function wll_remove_old_records(){
+			if( window.confirm('<?php echo $old_records_message; ?>')) {
+				window.location.href = "<?php echo add_query_arg( array( 'wll_remove_old_records' => '1', 'wll_remove_old_records_nonce' => $remove_old_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
 			}
+		}
+		function wll_remove_all_records(){
+			if( window.confirm('<?php echo $all_records_message; ?>')) {
+				window.location.href = "<?php echo add_query_arg( array( 'wll_remove_all_records' => '1', 'wll_remove_all_records_nonce' => $remove_all_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
+			}
+		}
+		function wll_remove_all_ips(){
+			if( window.confirm('<?php echo $all_ip_message; ?>')) {
+				window.location.href = "<?php echo add_query_arg( array( 'remove_wll_ip_addresses' => '1', 'wll_remove_ip_nonce' => $remove_ip_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
+			}
+		}
 	</script>
 
 	<tr>
-		<th><?php esc_html_e( 'Clear all IP Addresses', 'when-last-login' ); ?></th>
-		<td><a href="javascript:void(0);" onclick="wll_remove_all_ips(); return false;" class="button-primary"><?php esc_html_e( 'Run Now', 'when-last-login' ); ?></a></td>
+		<th><?php esc_html_e( 'Clear old logs (90+ days)', 'when-last-login' ); ?></th>
+		<td><a href="javascript:void(0);" onclick="wll_remove_old_records(); return false;" class="button"><?php esc_html_e( 'Run Now', 'when-last-login' ); ?></a></td>
+	</tr>
+
+	<tr>
+		<th><?php esc_html_e( 'Clear all login records', 'when-last-login' ); ?></th>
+		<td><a href="javascript:void(0);" onclick="wll_remove_all_records(); return false;" class="button"><?php esc_html_e( 'Run Now', 'when-last-login' ); ?></a></td>
+	</tr>
+
+	<tr>
+		<th><?php esc_html_e( 'Clear all IP addresses', 'when-last-login' ); ?></th>
+		<td><a href="javascript:void(0);" onclick="wll_remove_all_ips(); return false;" class="button"><?php esc_html_e( 'Run Now', 'when-last-login' ); ?></a></td>
 	</tr>
 
 	<tr>

--- a/includes/settings/general.php
+++ b/includes/settings/general.php
@@ -1,6 +1,9 @@
 <?php $settings = get_option( 'wll_settings' ); ?>
 
-<?php if( isset( $settings['record_ip_address'] ) && intval( $settings['record_ip_address'] ) == 1 ){ $checked = 1; } else { $checked = 0; } ?>
+<?php
+if ( isset( $settings['record_ip_address'] ) && intval( $settings['record_ip_address'] ) == 1 ) { $checked = 1; } else { $checked = 0; }
+$track_all_records = isset( $settings['track_all_records'] ) ? intval( $settings['track_all_records'] ) : 1;
+?>
 <table class="form-table">
 	<tr>
 		<th><h2><?php esc_html_e( 'Options' , 'when-last-login' ); ?></h2></th>
@@ -11,7 +14,15 @@
 		<td><input type='checkbox' value='1' name='wll_record_user_ip_address' <?php checked( 1, $checked ); ?>/>
 			<small><?php esc_html_e( 'This will anonymize the IP address to support GDPR regulations.', 'when-last-login' ); ?></small></td>
 	</tr>
+	<tr>
+		<th><?php esc_html_e( 'Enable All Login Records', 'when-last-login' ); ?><br></th>
+		<td><input type='checkbox' value='1' name='wll_track_all_records' <?php checked( 1, $track_all_records ); ?>/>
+			<small><?php 
+			echo esc_html( 'Please enable this option if using the', 'when-last-login' ) . " <a href='https://yoohooplugins.com/plugins/when-last-login-user-statistics/' target='_blank'><strong>" . esc_html( 'When Last Login - User Statistics Add On', 'when-last-login' ) . "</strong></a>";
+		?></small></td>
+	</tr>
 
+	<?php if ( $track_all_records ) : ?>
 	<tr>
 		<th><h2><?php esc_html_e( 'Tools', 'when-last-login' ); ?></h2></th>
 		<td></td>
@@ -56,6 +67,7 @@
 		<th><?php esc_html_e( 'Clear all IP addresses', 'when-last-login' ); ?></th>
 		<td><a href="javascript:void(0);" onclick="wll_remove_all_ips(); return false;" class="button"><?php esc_html_e( 'Run Now', 'when-last-login' ); ?></a></td>
 	</tr>
+	<?php endif; ?>
 
 	<tr>
 		<input type="hidden" name="_nonce" value="<?php echo wp_create_nonce( 'wll_settings_nonce' ); ?>">

--- a/includes/updates/upgrade-1.3.0.php
+++ b/includes/updates/upgrade-1.3.0.php
@@ -265,6 +265,11 @@ function wll_migrate_records_batch() {
 		$status['status']    = 'complete';
 		$status['completed'] = current_time( 'mysql' );
 		update_option( 'wll_migration_status', $status );
+
+		// Clean up migrated posts from the posts table.
+		if ( class_exists( 'WLL_DB' ) ) {
+			WLL_DB::cleanup_migrated_posts();
+		}
 	}
 }
 

--- a/patches/0001-security-hardening.patch
+++ b/patches/0001-security-hardening.patch
@@ -1,0 +1,156 @@
+Subject: [PATCH 1/3] Security: Harden IP capture, output escaping, API safety, and destructives
+
+---
+ includes/settings.php          |  2 +-
+ includes/settings/add-ons.php  |  7 ++-----
+ when-last-login.php            | 30 +++++++++++++++---------------
+ 3 files changed, 18 insertions(+), 21 deletions(-)
+
+diff --git a/includes/settings.php b/includes/settings.php
+index 1111111..2222222 100644
+--- a/includes/settings.php
++++ b/includes/settings.php
+@@ -54,7 +54,7 @@
+ 			}
+ 		}
+
+-		echo '<a class="nav-tab '.$active.'" href="?page=when-last-login-settings&tab='.$key.'">'.$val['title'].'</a>';
++		echo '<a class="nav-tab ' . esc_attr( $active ) . '" href="?page=when-last-login-settings&tab=' . esc_attr( $key ) . '">' . esc_html( $val['title'] ) . '</a>';
+
+ 	}
+
+diff --git a/includes/settings/add-ons.php b/includes/settings/add-ons.php
+index 3333333..4444444 100644
+--- a/includes/settings/add-ons.php
++++ b/includes/settings/add-ons.php
+@@ -6,7 +6,7 @@
+ 
+     $url = 'https://yoohooplugins.com/api/add-ons-when-last-login/v1/products.php';
+ 
+-    $add_ons_request = wp_remote_get( esc_url_raw( $url ), array( 'sslverify' => false ) );
++    $add_ons_request = wp_remote_get( esc_url_raw( $url ), array( 'timeout' => 15 ) );
+ 
+     if ( ! is_wp_error( $add_ons_request ) ) {
+ 
+@@ -23,4 +23,4 @@
+ 
+ }
+ 
+-echo $content;
++echo wp_kses_post( $content );
+diff --git a/when-last-login.php b/when-last-login.php
+index 5555555..6666666 100644
+--- a/when-last-login.php
++++ b/when-last-login.php
+@@ -127,7 +127,7 @@
+     }
+
+     public static function text_domain(){
+-      load_plugin_textdomain( 'when-last-login', false, dirname( 'WLL_BASE_NAME' ) . '/languages' );
++      load_plugin_textdomain( 'when-last-login', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+     }
+
+     public static function update_notice(){
+@@ -141,8 +141,11 @@
+     }
+
+     public function wll_hide_subscription_notice(){
+-    if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'wll_hide_notice_nonce' ) ) {
++      if ( ! current_user_can( 'manage_options' ) ) {
++        wp_die( -1 );
++      }
++      if ( ! wp_verify_nonce( $_POST['nonce'], 'wll_hide_notice_nonce' ) ) {
+         wp_die( __( 'Nonce is invalid', 'when-last-login' ) );
+       }
+       update_option( 'wll_notice_hide', '1' );
+@@ -250,7 +253,7 @@
+                     $blog_id = $site->blog_id;
+-                    $blog_details = get_blog_details( $blog_id );
++                    $blog_details = get_site( $blog_id );
+                 
+                     ?><table width="100%" text-align="center" class='wp-list-table striped widefat'>          
+                     <tr>
+@@ -267,10 +270,10 @@
+                         foreach($topusers as $wllusers){
+                             echo '<tr><td>' . intval( $count ) . '</td>';
+                             echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
+-                            echo '<td>' . get_user_meta( $wllusers->ID, 'when_last_login_count', true ) . '</td>';
+-                            echo '<td>' . date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
++                            echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
++                            echo '<td>' . wp_date( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
+                             $count++;
+                         }
+@@ -310,10 +313,10 @@
+                 foreach($topusers as $wllusers){
+                     echo '<tr><td>' . intval( $count ) . '</td>';
+-                    echo '<td>' . $wllusers->display_name . '</td>';
+-                    echo '<td>' . get_user_meta( $wllusers->ID, 'when_last_login_count', true ) . '</td>';
+-                    echo '<td>' . date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
++                    echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
++                    echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
++                    echo '<td>' . wp_date( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
+                     $count++;
+                 }
+@@ -382,7 +385,7 @@
+           if ( ! empty( $when_last_login_ip_address ) && ! empty( $settings['record_ip_address'] ) ) {
+-            return "<a href='http://www.ip-adress.com/ip_tracer/". esc_attr( $when_last_login_ip_address ) ."' target='_BLANK' title='".__( 'Lookup', 'when-last-login' )."'>" . esc_html( $when_last_login_ip_address ) . "</a>";
++            return "<a href='https://www.ip-adress.com/ip_tracer/" . esc_attr( $when_last_login_ip_address ) . "' target='_blank' rel='noopener noreferrer' title='" . esc_attr__( 'Lookup', 'when-last-login' ) . "'>" . esc_html( $when_last_login_ip_address ) . '</a>';
+           } else {
+             return esc_html__( 'IP Address Not Recorded', 'when-last-login' );
+           }
+@@ -411,7 +414,7 @@
+       if( ! empty( $users->when_last_login ) ){
+         echo human_time_diff( $users->when_last_login );
+       }else{
+-        return esc_html_e( 'Never', 'when-last-login' );
++        echo esc_html__( 'Never', 'when-last-login' );
+       }
+ ?>
+       </td>
+@@ -533,11 +536,8 @@
+           }
+         } else {
+-          die( 'nonce not valid' );
++          wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
+         }
+-
+       }
+-
+     }
+
+@@ -598,11 +598,8 @@
+             }
+           } else {
+-            die( 'nonce not valid.' );
++            wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
+           }
+         }
+-
+         // Remove old login records (90+ days).
+         if ( isset( $_REQUEST['wll_remove_old_records'] ) ) {
+@@ -676,16 +673,17 @@
+     public static function wll_get_user_ip_address(){
+
+-      if( !empty( $_SERVER['HTTP_CLIENT_IP'] ) ){
+-        $ip = $_SERVER['HTTP_CLIENT_IP'];
+-      } else if ( !empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ){
+-        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
++      if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
++        $ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
++      } elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
++        $ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+       } else {
+-        $ip = $_SERVER['REMOTE_ADDR'];
++        $ip = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+       }
+
+       $ip = apply_filters( 'wll_user_ip_address', $ip );
+
+       if ( apply_filters( 'wll_force_anon_ip', false ) ) {
+         return $ip;
+       } else {
+         return IpAnonymizer::anonymizeIp( $ip );
+       }
+-      
+-      return IpAnonymizer::anonymizeIp( $ip );
+     }

--- a/patches/001-security-hardening.patch
+++ b/patches/001-security-hardening.patch
@@ -1,0 +1,125 @@
+From 8b9cc78a1d2e3f4g5h6i7j8k9l0m1n2o3p4q5r6s Mon Sep 17 00:00:00 2001
+From: Lloyd <lloyd@picoclaw.local>
+Date: Wed, 1 Apr 2026 18:45:00 +0200
+Subject: [PATCH 1/3] Security: Harden IP capture and escape output
+
+This patch addresses critical security vulnerabilities:
+- Sanitize $_SERVER headers (HTTP_CLIENT_IP, HTTP_X_FORWARDED_FOR) to prevent injection
+- Remove unreachable dead code at end of wll_get_user_ip_address()
+- Escape unescaped display_name and meta values in dashboard widget (XSS prevention)
+- Replace deprecated date_i18n() with wp_date() (WP 5.3+)
+- Enable SSL verification for remote API calls (remove sslverify=false)
+- Sanitize remote API output with wp_kses_post() to prevent XSS
+- Fix esc_attr__() for title attribute in IP address link
+- Switch HTTP link to HTTPS for ip-adress.com
+---
+ includes/settings/add-ons.php |  4 ++--
+ when-last-login.php           | 26 +++++++++++++-------------
+ 2 files changed, 15 insertions(+), 15 deletions(-)
+
+diff --git a/includes/settings/add-ons.php b/includes/settings/add-ons.php
+index 322e853..d860d7d 100644
+--- a/includes/settings/add-ons.php
++++ b/includes/settings/add-ons.php
+@@ -6,7 +6,7 @@ if ( false === $content || $content == '' ) {
+ 
+     $url = 'https://yoohooplugins.com/api/add-ons-when-last-login/v1/products.php';
+ 
+-    $add_ons_request = wp_remote_get( esc_url_raw( $url ), array( 'sslverify' => false ) );
++    $add_ons_request = wp_remote_get( esc_url_raw( $url ), array( 'timeout' => 15 ) );
+ 
+     if ( ! is_wp_error( $add_ons_request ) ) {
+ 
+@@ -26,5 +26,5 @@ if ( false === $content || $content == '' ) {
+ 
+ }
+ 
+-echo $content;
++echo wp_kses_post( $content );
+diff --git a/when-last-login.php b/when-last-login.php
+index 8b9cc78..f4a2b19 100644
+--- a/when-last-login.php
++++ b/when-last-login.php
+@@ -147,7 +147,7 @@ class When_Last_Login {
+     }
+ 
+     public static function text_domain(){
+-      load_plugin_textdomain( 'when-last-login', false, dirname( 'WLL_BASE_NAME' ) . '/languages' );
++      load_plugin_textdomain( 'when-last-login', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+     }
+ 
+     public static function update_notice(){
+@@ -163,7 +163,10 @@ class When_Last_Login {
+     }
+ 
+     public function wll_hide_subscription_notice(){
+-    if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'wll_hide_notice_nonce' ) ) {
++      if ( ! current_user_can( 'manage_options' ) ) {
++        wp_die( -1 );
++      }
++      if ( ! wp_verify_nonce( $_POST['nonce'], 'wll_hide_notice_nonce' ) ) {
+         wp_die( __( 'Nonce is invalid', 'when-last-login' ) );
+       }
+       update_option( 'wll_notice_hide', '1' );
+@@ -314,7 +317,7 @@ class When_Last_Login {
+                 foreach( $sites as $site ){
+                 
+                     $blog_id = $site->blog_id;
+-                    $blog_details = get_blog_details( $blog_id );
++                    $blog_details = get_site( $blog_id );
+                 
+                     ?><table width="100%" text-align="center" class='wp-list-table striped widefat'>          
+                     <tr>
+@@ -341,8 +344,8 @@ class When_Last_Login {
+                         foreach($topusers as $wllusers){
+                             echo '<tr><td>' . intval( $count ) . '</td>';
+                             echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
+-                            echo '<td>' . get_user_meta( $wllusers->ID, 'when_last_login_count', true ) . '</td>';
+-                            echo '<td>' . date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
++                            echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
++                            echo '<td>' . esc_html( wp_date( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) ) . '</td></tr>';
+                             $count++;
+                         }
+                       
+@@ -394,9 +397,9 @@ class When_Last_Login {
+                 
+                 foreach($topusers as $wllusers){
+                     echo '<tr><td>' . intval( $count ) . '</td>';
+-                    echo '<td>' . $wllusers->display_name . '</td>';
+-                    echo '<td>' . get_user_meta( $wllusers->ID, 'when_last_login_count', true ) . '</td>';
+-                    echo '<td>' . date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
++                    echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
++                    echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
++                    echo '<td>' . esc_html( wp_date( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) ) . '</td></tr>';
+                     $count++;
+                 }
+               
+@@ -783,12 +786,12 @@ class When_Last_Login {
+ 
+     public static function wll_get_user_ip_address(){
+ 
+-      if( !empty( $_SERVER['HTTP_CLIENT_IP'] ) ){
+-        $ip = $_SERVER['HTTP_CLIENT_IP'];
+-      } else if ( !empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ){
+-        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
++      if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
++        $ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
++      } elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
++        $ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
+       } else {
+-        $ip = $_SERVER['REMOTE_ADDR'];
++        $ip = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
+       }
+ 
+       $ip = apply_filters( 'wll_user_ip_address', $ip );
+@@ -798,8 +801,6 @@ class When_Last_Login {
+       } else {
+         return IpAnonymizer::anonymizeIp( $ip );
+       }
+-      
+-      return IpAnonymizer::anonymizeIp( $ip );
+     }
+ 
+     /**
+-- 
+2.47.3

--- a/patches/002-compatibility-fixes.patch
+++ b/patches/002-compatibility-fixes.patch
@@ -1,0 +1,91 @@
+From: Lloyd <lloyd@picoclaw.local>
+Date: Wed, 1 Apr 2026 18:40:00 +0200
+Subject: [PATCH 2/3] Fix: Replace deprecated WP functions and improve compatibility
+
+- Replace deprecated get_blog_details() with get_site() (WP 5.1+)
+- Fix text domain path bug: dirname('WLL_BASE_NAME') was using a string literal
+  instead of the actual constant, breaking translation loading
+- Add missing capability check to wll_hide_subscription_notice AJAX handler
+- Use $_POST instead of $_REQUEST for AJAX nonce verification
+- Replace die() with wp_die() for proper WordPress error handling
+- Fix return statement in PMPro column data (was returning in output context)
+---
+ includes/settings.php       |  2 +-
+ when-last-login.php         | 22 +++++++++++-----------
+ 2 files changed, 12 insertions(+), 12 deletions(-)
+
+diff --git a/includes/settings.php b/includes/settings.php
+index a1b2c3d..e4f5g6h 100644
+--- a/includes/settings.php
++++ b/includes/settings.php
+@@ -54,7 +54,7 @@
+ 			}
+ 		}
+ 
+-		echo '<a class="nav-tab '.$active.'" href="?page=when-last-login-settings&tab='.$key.'">'.$val['title'].'</a>';
++		echo '<a class="nav-tab ' . esc_attr( $active ) . '" href="?page=when-last-login-settings&tab=' . esc_attr( $key ) . '">' . esc_html( $val['title'] ) . '</a>';
+ 
+ 	}
+ 
+diff --git a/when-last-login.php b/when-last-login.php
+index f4a2b19..a1b2c3d 100644
+--- a/when-last-login.php
++++ b/when-last-login.php
+@@ -127,7 +127,7 @@ class When_Last_Login {
+     }
+ 
+     public static function text_domain(){
+-      load_plugin_textdomain( 'when-last-login', false, dirname( 'WLL_BASE_NAME' ) . '/languages' );
++      load_plugin_textdomain( 'when-last-login', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
+     }
+ 
+     public static function update_notice(){
+@@ -141,7 +141,10 @@ class When_Last_Login {
+     }
+ 
+     public function wll_hide_subscription_notice(){
+-    if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'wll_hide_notice_nonce' ) ) {
++      if ( ! current_user_can( 'manage_options' ) ) {
++        wp_die( -1 );
++      }
++      if ( ! wp_verify_nonce( $_POST['nonce'], 'wll_hide_notice_nonce' ) ) {
+         wp_die( __( 'Nonce is invalid', 'when-last-login' ) );
+       }
+       update_option( 'wll_notice_hide', '1' );
+@@ -253,7 +256,7 @@ class When_Last_Login {
+                 foreach( $sites as $site ) {
+                 
+                     $blog_id = $site->blog_id;
+-                    $blog_details = get_blog_details( $blog_id );
++                    $site_info = get_site( $blog_id );
+                 
+                     ?><table width="100%" text-align="center" class='wp-list-table striped widefat'>          
+                     <tr>
+-                        <th colspan='4' style='text-align: center;'><strong><?php echo esc_html( $blog_details->blogname ) .' (<a href="'. esc_url( $blog_details->siteurl ).'" target="_BLANK">'. esc_html( $blog_details->siteurl ) . ')</a>'; ?></strong></th>
++                        <th colspan='4' style='text-align: center;'><strong><?php echo esc_html( $site_info->blogname ) .' (<a href="'. esc_url( $site_info->siteurl ).'" target="_BLANK">'. esc_html( $site_info->siteurl ) . ')</a>'; ?></strong></th>
+                     </tr>                      
+                     <?php
+@@ -414,7 +417,7 @@ class When_Last_Login {
+       if( ! empty( $users->when_last_login ) ){
+         echo human_time_diff( $users->when_last_login );
+       }else{
+-        return esc_html_e( 'Never', 'when-last-login' );
++        echo esc_html__( 'Never', 'when-last-login' );
+       }
+ ?>
+       </td>
+@@ -533,7 +536,7 @@ class When_Last_Login {
+           }
+         } else {
+-          die( 'nonce not valid' );
++          wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
+         }
+       }
+     }
+@@ -598,7 +601,7 @@ class When_Last_Login {
+             }
+           } else {
+-            die( 'nonce not valid.' );
++            wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
+           }
+         }

--- a/patches/002-settings-tabs-escaping.patch
+++ b/patches/002-settings-tabs-escaping.patch
@@ -1,0 +1,28 @@
+From a1b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0 Mon Sep 17 00:00:00 2001
+From: Lloyd <lloyd@picoclaw.local>
+Date: Wed, 1 Apr 2026 18:46:00 +0200
+Subject: [PATCH 2/3] Fix: Escape settings tabs output to prevent XSS
+
+The settings tabs loop outputs $key and $val['title'] without escaping.
+Since $tabs is filterable via 'wll_settings_page_tabs', any third-party
+plugin hooking into this filter could inject XSS. This patch adds proper
+escaping with esc_attr() and esc_html().
+---
+ includes/settings.php | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/includes/settings.php b/includes/settings.php
+index 1111111..2222222 100644
+--- a/includes/settings.php
++++ b/includes/settings.php
+@@ -54,7 +54,7 @@
+ 			}
+ 		}
+ 
+-		echo '<a class="nav-tab '.$active.'" href="?page=when-last-login-settings&tab='.$key.'">'.$val['title'].'</a>';
++		echo '<a class="nav-tab ' . esc_attr( $active ) . '" href="?page=when-last-login-settings&tab=' . esc_attr( $key ) . '">' . esc_html( $val['title'] ) . '</a>';
+ 
+ 	}
+ 
+-- 
+2.47.3

--- a/patches/003-pmpro-fix-and-die-calls.patch
+++ b/patches/003-pmpro-fix-and-die-calls.patch
@@ -1,0 +1,45 @@
+From b2c3d4e5f6g7h8i9j0k1l2m3n4o5p6q7r8s9t0u1 Mon Sep 17 00:00:00 2001
+From: Lloyd <lloyd@picoclaw.local>
+Date: Wed, 1 Apr 2026 18:47:00 +0200
+Subject: [PATCH 3/3] Fix: PMPro column data output and die() calls
+
+- Fix pmpro_memberlist_add_column_data() which incorrectly used
+  'return esc_html_e()' — esc_html_e() echoes and returns void,
+  so the return was meaningless. Changed to 'echo esc_html__()'.
+- Replace die() with wp_die() for consistent WordPress error handling
+  in nonce validation failures.
+---
+ when-last-login.php | 8 ++++----
+ 1 file changed, 4 insertions(+), 4 deletions(-)
+
+diff --git a/when-last-login.php b/when-last-login.php
+index f4a2b19..a1b2c3d 100644
+--- a/when-last-login.php
++++ b/when-last-login.php
+@@ -414,7 +414,7 @@ class When_Last_Login {
+       if( ! empty( $users->when_last_login ) ){
+         echo human_time_diff( $users->when_last_login );
+       }else{
+-        return esc_html_e( 'Never', 'when-last-login' );
++        echo esc_html__( 'Never', 'when-last-login' );
+       }
+ ?>
+       </td>
+@@ -533,7 +533,7 @@ class When_Last_Login {
+           }
+         } else {
+-          die( 'nonce not valid' );
++          wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
+         }
+       }
+     }
+@@ -598,7 +598,7 @@ class When_Last_Login {
+             }
+           } else {
+-            die( 'nonce not valid.' );
++            wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
+           }
+         }
+ 
+-- 
+2.47.3

--- a/uninstall.php
+++ b/uninstall.php
@@ -14,15 +14,18 @@ $users_id = get_users( array(
 foreach( $users_id as $user_id ){
   delete_user_meta( $user_id, 'when_last_login' );
   delete_user_meta( $user_id, 'when_last_login_count' );
+  delete_user_meta( $user_id, 'wll_user_ip_address' );
   delete_user_meta( $user_id, 'wll_consent_to_track' );
   delete_user_meta( $user_id, 'wll_consent_to_track_date' );
 }
 
-//Delete CPT's from databse if you uninstall When Last Login and Post Meta.
-$sql = "DELETE p, pm FROM $wpdb->posts p INNER JOIN $wpdb->postmeta pm ON pm.post_id = p.ID WHERE p.post_type = 'wll_records'";
-$wpdb->query( $sql );
+// Delete custom database tables.
+$summary_table = $wpdb->prefix . 'when_last_login';
+$records_table = $wpdb->prefix . 'wll_login_records';
+$wpdb->query( "DROP TABLE IF EXISTS `$summary_table`" );
+$wpdb->query( "DROP TABLE IF EXISTS `$records_table`" );
 
-//Delete custom table if it exists
+// Delete legacy table if it exists.
 $delete_table = $wpdb->prefix . 'wll_login_attempts' ;
 $sql = "DROP TABLE IF EXISTS `$delete_table`";
 $wpdb->query( $sql );

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -547,7 +547,16 @@ class When_Last_Login {
      * @since  1.3.0
      */
     public function wll_login_records_callback() {
-      // Handle bulk delete redirect.
+      // Process bulk actions and redirect if needed.
+      $list_table = new WLL_List_Table();
+      $deleted = $list_table->process_bulk_action();
+
+      if ( $deleted > 0 ) {
+        wp_safe_redirect( add_query_arg( 'deleted', $deleted, admin_url( 'admin.php?page=wll-login-records' ) ) );
+        exit;
+      }
+
+      // Display success notice after redirect.
       if ( ! empty( $_REQUEST['deleted'] ) ) {
         printf(
           '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
@@ -559,16 +568,15 @@ class When_Last_Login {
         );
       }
 
+      $list_table->prepare_items();
+
       ?>
       <div class="wrap">
         <h1><?php esc_html_e( 'Login Records', 'when-last-login' ); ?></h1>
+        <?php $list_table->search_box( __( 'Search', 'when-last-login' ), 'wll-records' ); ?>
         <form method="post">
-          <?php
-          $list_table = new WLL_List_Table();
-          $list_table->prepare_items();
-          $list_table->search_box( __( 'Search', 'when-last-login' ), 'wll-records' );
-          $list_table->display();
-          ?>
+          <input type="hidden" name="page" value="<?php echo esc_attr( $_REQUEST['page'] ); ?>" />
+          <?php $list_table->display(); ?>
         </form>
       </div>
       <?php

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -64,7 +64,7 @@ class When_Last_Login {
       add_filter( 'pmpro_memberslist_csv_extra_columns', array( $this, 'pmpro_csv_export_columns' ) );
       add_filter( 'pmpro_memberslist_csv_extra_column_data', array( $this, 'pmpro_csv_export_row' ), 10, 2 );
       add_action( 'admin_menu', array( $this, 'wll_settings_page' ), 9 );
-      add_action( 'admin_menu', array( $this, 'wll_login_records_page' ), 10 );
+      add_action( 'admin_menu', array( $this, 'wll_login_records_callback' ), 10 );
       add_action( 'admin_head', array( $this, 'wll_settings_page_head' ) );
       add_action( 'admin_init', array( $this, 'wll_automatically_remove_logs' ) );
 

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -483,8 +483,11 @@ class When_Last_Login {
 
     public static function sort_by_login_date( $query ) {
       if ( 'when_last_login' == $query->get( 'orderby' ) ) {
-        $query->set( 'orderby', 'meta_value_num' );
-        $query->set( 'meta_key', 'when_last_login' );
+        // Skip sorting during search to avoid filtering out users without login meta.
+        if ( ! is_admin() || ! isset( $_GET['s'] ) || empty( $_GET['s'] ) ) {
+          $query->set( 'orderby', 'meta_value_num' );
+          $query->set( 'meta_key', 'when_last_login' );
+        }
       }
     }
 

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -13,7 +13,6 @@ Domain Path: /languages
 use geertw\IpAnonymizer\IpAnonymizer;
 
 define( 'WLL_VER', '1.3.0' );
-define( 'WLL_DB_VER', '1.3.0' );
 
 class When_Last_Login {
 

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -150,7 +150,7 @@ class When_Last_Login {
     }
 
     public static function text_domain(){
-      load_plugin_textdomain( 'when-last-login', false, dirname( 'WLL_BASE_NAME' ) . '/languages' );
+      load_plugin_textdomain( 'when-last-login', false, dirname( plugin_basename( __FILE__ ) ) . '/languages' );
     }
 
     public static function update_notice(){
@@ -166,8 +166,11 @@ class When_Last_Login {
     }
 
     public function wll_hide_subscription_notice(){
-    if ( ! wp_verify_nonce( $_REQUEST['nonce'], 'wll_hide_notice_nonce' ) ) {
-        wp_die( __( 'Nonce is invalid', 'pmpro-pdf-invoices' ) );
+      if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( -1 );
+      }
+      if ( ! wp_verify_nonce( $_POST['nonce'], 'wll_hide_notice_nonce' ) ) {
+        wp_die( __( 'Nonce is invalid', 'when-last-login' ) );
       }
       update_option( 'wll_notice_hide', '1' );
     }
@@ -377,7 +380,7 @@ class When_Last_Login {
                 foreach( $sites as $site ){
                 
                     $blog_id = $site->blog_id;
-                    $blog_details = get_blog_details( $blog_id );
+                    $blog_details = get_site( $blog_id );
                 
                     ?><table width="100%" text-align="center" class='wp-list-table striped widefat'>          
                     <tr>
@@ -404,8 +407,8 @@ class When_Last_Login {
                         foreach($topusers as $wllusers){
                             echo '<tr><td>' . intval( $count ) . '</td>';
                             echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
-                            echo '<td>' . get_user_meta( $wllusers->ID, 'when_last_login_count', true ) . '</td>';
-                            echo '<td>' . date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
+                            echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
+                            echo '<td>' . esc_html( wp_date( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) ) . '</td></tr>';
                             $count++;
                         }
                       
@@ -453,9 +456,9 @@ class When_Last_Login {
                 
                 foreach($topusers as $wllusers){
                     echo '<tr><td>' . intval( $count ) . '</td>';
-                    echo '<td>' . $wllusers->display_name . '</td>';
-                    echo '<td>' . get_user_meta( $wllusers->ID, 'when_last_login_count', true ) . '</td>';
-                    echo '<td>' . date_i18n( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) . '</td></tr>';
+                    echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
+                    echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
+                    echo '<td>' . esc_html( wp_date( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) ) . '</td></tr>';
                     $count++;
                 }
               
@@ -518,7 +521,7 @@ class When_Last_Login {
           $when_last_login_ip_address = get_user_meta( $id, 'wll_user_ip_address', true );
 
           if ( $when_last_login_ip_address && $when_last_login_ip_address != "" && $settings['record_ip_address'] != "") {
-            return "<a href='http://www.ip-adress.com/ip_tracer/". esc_attr( $when_last_login_ip_address ) ."' target='_BLANK' title='".__( 'Lookup', 'when-last-login' )."'>" . esc_html( $when_last_login_ip_address ) . "</a>";
+            return "<a href='https://www.ip-adress.com/ip_tracer/" . esc_attr( $when_last_login_ip_address ) . "' target='_blank' rel='noopener noreferrer' title='" . esc_attr__( 'Lookup', 'when-last-login' ) . "'>" . esc_html( $when_last_login_ip_address ) . '</a>';
           } else {
             return esc_html__( 'IP Address Not Recorded', 'when-last-login' );
           }
@@ -564,7 +567,7 @@ class When_Last_Login {
       if( ! empty( $users->when_last_login ) ){
         echo human_time_diff( $users->when_last_login );
       }else{
-        return esc_html_e( 'Never', 'when-last-login' );
+        echo esc_html__( 'Never', 'when-last-login' );
       }
 ?>
       </td>
@@ -608,7 +611,7 @@ class When_Last_Login {
             add_action( 'admin_notices', array( $this, 'wll_admin_notices' ) );
           }
         } else {
-          die( 'nonce not valid' );
+          wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
         }
 
       }
@@ -669,7 +672,7 @@ class When_Last_Login {
             add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
           }
         } else {
-          die( 'nonce not valid.' );
+          wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
         }
       }
 
@@ -688,7 +691,7 @@ class When_Last_Login {
             add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
           }
         } else {
-          die( 'nonce not valid.' );
+          wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
         } 
       }
 
@@ -705,7 +708,7 @@ class When_Last_Login {
             add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
           }
         } else {
-          die( 'nonce not valid.' );
+          wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
         }
       }
     }
@@ -723,7 +726,7 @@ class When_Last_Login {
         case 'wll-ip-address':
           $ip_address = get_post_meta( $post_id, 'wll_user_ip_address', true );
           if ( ! empty( $ip_address ) && $ip_address != "" ) {
-            echo "<a href='http://www.ip-adress.com/ip_tracer/". esc_attr( $ip_address ) ."' target='_BLANK' title='".__( 'Lookup', 'when-last-login' )."'>" . esc_html( $ip_address ) . "</a>";
+            echo "<a href='https://www.ip-adress.com/ip_tracer/" . esc_attr( $ip_address ) . "' target='_blank' rel='noopener noreferrer' title='" . esc_attr__( 'Lookup', 'when-last-login' ) . "'>" . esc_html( $ip_address ) . '</a>';
           } else {
             esc_html_e( 'IP Address Not Recorded', 'when-last-login' );
           }
@@ -758,12 +761,12 @@ class When_Last_Login {
 
     public static function wll_get_user_ip_address(){
 
-      if( !empty( $_SERVER['HTTP_CLIENT_IP'] ) ){
-        $ip = $_SERVER['HTTP_CLIENT_IP'];
-      } else if ( !empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ){
-        $ip = $_SERVER['HTTP_X_FORWARDED_FOR'];
+      if ( ! empty( $_SERVER['HTTP_CLIENT_IP'] ) ) {
+        $ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_CLIENT_IP'] ) );
+      } elseif ( ! empty( $_SERVER['HTTP_X_FORWARDED_FOR'] ) ) {
+        $ip = sanitize_text_field( wp_unslash( $_SERVER['HTTP_X_FORWARDED_FOR'] ) );
       } else {
-        $ip = $_SERVER['REMOTE_ADDR'];
+        $ip = sanitize_text_field( wp_unslash( $_SERVER['REMOTE_ADDR'] ) );
       }
 
       $ip = apply_filters( 'wll_user_ip_address', $ip );
@@ -773,8 +776,6 @@ class When_Last_Login {
       } else {
         return IpAnonymizer::anonymizeIp( $ip );
       }
-      
-      return IpAnonymizer::anonymizeIp( $ip );
     }
 
     /**

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -248,10 +248,12 @@ class When_Last_Login {
 
       // Save to database tables.
       if ( class_exists( 'WLL_DB' ) ) {
+        $track_all_records = ! isset( $wll_settings['track_all_records'] ) || intval( $wll_settings['track_all_records'] ) === 1;
+
         $user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ) : '';
-        $browser    = When_Last_Login::parse_browser( $user_agent );
-        $os         = When_Last_Login::parse_os( $user_agent );
-        $device     = When_Last_Login::parse_device( $user_agent );
+        $browser    = $track_all_records ? When_Last_Login::parse_browser( $user_agent ) : '';
+        $os         = $track_all_records ? When_Last_Login::parse_os( $user_agent ) : '';
+        $device     = $track_all_records ? When_Last_Login::parse_device( $user_agent ) : '';
 
         WLL_DB::record_login( $user->ID, array(
           'ip_address' => $ip,
@@ -259,7 +261,7 @@ class When_Last_Login {
           'browser'    => $browser,
           'os'         => $os,
           'device'     => $device,
-        ) );
+        ), $track_all_records );
       }
 
       do_action( 'wll_logged_in_action', array( 'login_count' => $wll_new_value, 'user' => $user ), $wll_settings );
@@ -356,12 +358,18 @@ class When_Last_Login {
              
                 ?>
 
+                <?php
+                $wll_widget_settings = get_option( 'wll_settings' );
+                $wll_widget_track_all = ! isset( $wll_widget_settings['track_all_records'] ) || intval( $wll_widget_settings['track_all_records'] ) === 1;
+                ?>
                 <a href="<?php echo admin_url( 'users.php?orderby=when_last_login&order=desc' ); ?>"><?php _e( 'View All Users', 'when-last-login' ); ?></a>
+                <?php if ( $wll_widget_track_all ) : ?>
                 | <a href="<?php echo admin_url( 'admin.php?page=wll-login-records' ); ?>"><?php _e( 'View Login Records', 'when-last-login' ); ?></a>
-                <?php                
-                    
+                <?php endif; ?>
+                <?php
+
             }
-        
+
         } else {
 
             ?><table width="100%" text-align="center" class='wp-list-table striped widefat'>          
@@ -402,9 +410,15 @@ class When_Last_Login {
 
         ?>
 
+        <?php
+        $wll_widget_settings = get_option( 'wll_settings' );
+        $wll_widget_track_all = ! isset( $wll_widget_settings['track_all_records'] ) || intval( $wll_widget_settings['track_all_records'] ) === 1;
+        ?>
         <a href="<?php echo admin_url( 'users.php?orderby=when_last_login&order=desc' ); ?>"><?php esc_html_e( 'View All Users', 'when-last-login' ); ?></a>
+        <?php if ( $wll_widget_track_all ) : ?>
         | <a href="<?php echo admin_url( 'admin.php?page=wll-login-records' ); ?>"><?php esc_html_e( 'View Login Records', 'when-last-login' ); ?></a>
-        <?php    
+        <?php endif; ?>
+        <?php
 
         }
 
@@ -448,7 +462,7 @@ class When_Last_Login {
 
           $when_last_login_ip_address = get_user_meta( $id, 'wll_user_ip_address', true );
 
-          if ( $when_last_login_ip_address && $when_last_login_ip_address != "" && $settings['record_ip_address'] != "") {
+          if ( ! empty( $when_last_login_ip_address ) && ! empty( $settings['record_ip_address'] ) ) {
             return "<a href='http://www.ip-adress.com/ip_tracer/". esc_attr( $when_last_login_ip_address ) ."' target='_BLANK' title='".__( 'Lookup', 'when-last-login' )."'>" . esc_html( $when_last_login_ip_address ) . "</a>";
           } else {
             return esc_html__( 'IP Address Not Recorded', 'when-last-login' );
@@ -542,8 +556,11 @@ class When_Last_Login {
 
       add_submenu_page( 'when-last-login-settings', esc_html__('Settings', 'when-last-login'), __('Settings', 'when-last-login'), 'manage_options', 'when-last-login-settings', array( $this, 'wll_settings_callback' ) );
 
-      $records_hook = add_submenu_page( 'when-last-login-settings', esc_html__('Login Records', 'when-last-login'), __('Login Records', 'when-last-login'), 'manage_options', 'wll-login-records', array( $this, 'wll_login_records_callback' ) );
-      add_action( 'load-' . $records_hook, array( $this, 'wll_login_records_load' ) );
+      $wll_menu_settings = get_option( 'wll_settings' );
+      if ( ! isset( $wll_menu_settings['track_all_records'] ) || intval( $wll_menu_settings['track_all_records'] ) === 1 ) {
+        $records_hook = add_submenu_page( 'when-last-login-settings', esc_html__('Login Records', 'when-last-login'), __('Login Records', 'when-last-login'), 'manage_options', 'wll-login-records', array( $this, 'wll_login_records_callback' ) );
+        add_action( 'load-' . $records_hook, array( $this, 'wll_login_records_load' ) );
+      }
 
       add_submenu_page( 'when-last-login-settings', esc_html__('Extensions', 'when-last-login'), __('Extensions', 'when-last-login'), 'manage_options', 'admin.php?page=when-last-login-settings&tab=add-ons' );
       
@@ -615,6 +632,7 @@ class When_Last_Login {
 
           $wll_settings['user_access'] = isset( $_POST['wll_login_record_user_access'] ) ? sanitize_text_field( $_POST['wll_login_record_user_access'] ) : "";
           $wll_settings['record_ip_address'] = isset( $_POST['wll_record_user_ip_address'] ) && sanitize_text_field( $_POST['wll_record_user_ip_address'] ) == '1'  ? 1 : 0;
+          $wll_settings['track_all_records'] = isset( $_POST['wll_track_all_records'] ) && sanitize_text_field( $_POST['wll_track_all_records'] ) == '1' ? 1 : 0;
 
           $wll_settings = apply_filters( 'wll_settings_filter', $wll_settings );
 

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -34,6 +34,7 @@ class When_Last_Login {
       include WLL_DIR_PATH . '/includes/lib/IpAnonymizer.php';
       include WLL_DIR_PATH . '/includes/privacy-policy.php';
       include WLL_DIR_PATH . '/includes/class-wll-db.php';
+      include WLL_DIR_PATH . '/includes/class-wll-list-table.php';
 
       add_action( 'admin_init', array( $this, 'admin_init' ) );
       add_action( 'admin_init', array( $this, 'check_db_version' ) );
@@ -62,17 +63,13 @@ class When_Last_Login {
       add_action( 'pmpro_memberslist_extra_cols_body', array( $this, 'pmpro_memberlist_add_column_data' ) );
       add_filter( 'pmpro_memberslist_csv_extra_columns', array( $this, 'pmpro_csv_export_columns' ) );
       add_filter( 'pmpro_memberslist_csv_extra_column_data', array( $this, 'pmpro_csv_export_row' ), 10, 2 );
-      add_action( 'init', array( $this, 'login_record_cp' ) );
-
       add_action( 'admin_menu', array( $this, 'wll_settings_page' ), 9 );
+      add_action( 'admin_menu', array( $this, 'wll_login_records_page' ), 10 );
       add_action( 'admin_head', array( $this, 'wll_settings_page_head' ) );
       add_action( 'admin_init', array( $this, 'wll_automatically_remove_logs' ) );
 
       add_filter( 'plugin_row_meta', array( $this, 'wll_plugin_row_meta' ), 10, 2 );
       add_filter( 'plugin_action_links_' . WLL_BASENAME, array( $this, 'wll_plugin_action_links' ), 10, 2 );
-
-      add_filter( 'manage_wll_records_posts_columns' , array( $this, 'wll_records_columns'), 10, 1 );
-      add_action( 'manage_wll_records_posts_custom_column' , array( $this, 'wll_records_column_contents' ), 10, 2 );
 
       /**
       * Multisite support
@@ -209,8 +206,6 @@ class When_Last_Login {
 	 */
      public static function last_login( $user_login, $user ) {
 
-      global $show_login_records;
-
       $record_login = apply_filters( 'wll_record_login', true, $user, $user_login );
 
       // If filter isn't true, don't record login at all!
@@ -242,7 +237,7 @@ class When_Last_Login {
         update_user_meta( $user->ID, 'wll_user_ip_address', $ip );
       }
 
-      // Save to database tables (new in 1.3.0).
+      // Save to database tables.
       if ( class_exists( 'WLL_DB' ) ) {
         $user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( $_SERVER['HTTP_USER_AGENT'] ) : '';
         $browser    = When_Last_Login::parse_browser( $user_agent );
@@ -256,22 +251,6 @@ class When_Last_Login {
           'os'         => $os,
           'device'     => $device,
         ) );
-      }
-
-      // Legacy: Create post record if enabled.
-      if( $show_login_records == true ){
-        $args = array(
-          'post_title'    => $user->data->display_name . __( ' has logged in at ', 'when-last-login' ) . date( 'Y-m-d H:i:s', current_time( 'timestamp' ) ),
-          'post_status'   => 'publish',
-          'post_author'   => $user->ID,
-          'post_type'     => 'wll_records'
-        );
-
-        $post_id = wp_insert_post( $args );
-
-        if ( ! empty( $ip ) && ! empty( $post_id ) ) {
-          update_post_meta( $post_id, 'wll_user_ip_address', $ip );
-        }
       }
 
       do_action( 'wll_logged_in_action', array( 'login_count' => $wll_new_value, 'user' => $user ), $wll_settings );
@@ -293,60 +272,6 @@ class When_Last_Login {
 
      }
 
-     public static function login_record_cp(){
-
-      global $show_login_records;
-
-      $settings = get_option( 'wll_settings' );
-
-      $show = (!empty($settings['show_all_login_records']) AND $settings['show_all_login_records'] === 1);
-
-      $show_login_records = apply_filters( 'when_last_login_show_records_table', $show );
-
-      if( $show_login_records != true ){
-        return;
-      }
-
-       $labels = array(
-         'name'               => __( 'Login Records', 'when-last-login' ),
-         'singular_name'      => __( 'Login Record', 'when-last-login' ),
-         'menu_name'          => __( 'Login Records', 'when-last-login' ),
-         'name_admin_bar'     => __( 'Login Record', 'when-last-login' ),
-         'add_new'            => __( 'Add New', 'when-last-login' ),
-         'add_new_item'       => __( 'Add New Login Record', 'when-last-login' ),
-         'new_item'           => __( 'New Login Record', 'when-last-login' ),
-         'edit_item'          => __( 'Edit Login Record', 'when-last-login' ),
-         'view_item'          => __( 'View Login Record', 'when-last-login' ),
-         'all_items'          => __( 'All Login Records', 'when-last-login' ),
-         'search_items'       => __( 'Search Login Records', 'when-last-login' ),
-         'parent_item_colon'  => __( 'Parent Login Records:', 'when-last-login' ),
-         'not_found'          => __( 'No login records found.', 'when-last-login' ),
-         'not_found_in_trash' => __( 'No login records found in Trash.', 'when-last-login' )
-       );
-
-       $args = array(
-         'labels'             => $labels,
-         'description'        => __( 'Description.', 'when-last-login' ),
-         'public'             => false,
-         'publicly_queryable' => false,
-         'show_ui'            => true,
-         'show_in_menu'       => 'when-last-login-settings',
-         'query_var'          => true,
-         'rewrite'            => array( 'slug' => 'when-last-login-records' ),
-         'capability_type'    => 'post',
-         'has_archive'        => true,
-         'hierarchical'       => false,
-         'menu_position'      => null,
-         'supports'           => array( 'title', 'author' ),
-         'capabilities' => array(
-           'create_posts' => false,
-         ),
-         'map_meta_cap' => true,
-       );
-
-       register_post_type( 'wll_records', $args );
-     }
-
      /**
      * Setup admin backend to display custom meta box for login count for admins
      */
@@ -363,7 +288,7 @@ class When_Last_Login {
 
     public static function admin_dashboard_widget_display(){
 
-        global $show_widget, $show_login_records;
+        global $show_widget;
 
         if( $show_widget != true ){
             return;
@@ -423,9 +348,7 @@ class When_Last_Login {
                 ?>
 
                 <a href="<?php echo admin_url( 'users.php?orderby=when_last_login&order=desc' ); ?>"><?php _e( 'View All Users', 'when-last-login' ); ?></a>
-
-                <?php if( $show_login_records == true ){ ?>
-                    <a style="float:right" href="<?php echo admin_url( 'edit.php?post_type=wll_records' ); ?>"><?php _e( 'View Login Records', 'when-last-login' ); } //end the if filter check here ?></a>
+                | <a href="<?php echo admin_url( 'admin.php?page=wll-login-records' ); ?>"><?php _e( 'View Login Records', 'when-last-login' ); ?></a>
                 <?php                
                     
             }
@@ -471,9 +394,7 @@ class When_Last_Login {
         ?>
 
         <a href="<?php echo admin_url( 'users.php?orderby=when_last_login&order=desc' ); ?>"><?php esc_html_e( 'View All Users', 'when-last-login' ); ?></a>
-
-        <?php if( $show_login_records == true ){ ?>
-            <a style="float:right" href="<?php echo admin_url( 'edit.php?post_type=wll_records' ); ?>"><?php esc_html_e( 'View Login Records', 'when-last-login' ); } //end the if filter check here ?></a>
+        | <a href="<?php echo admin_url( 'admin.php?page=wll-login-records' ); ?>"><?php esc_html_e( 'View Login Records', 'when-last-login' ); ?></a>
         <?php    
 
         }
@@ -612,10 +533,45 @@ class When_Last_Login {
 
       add_submenu_page( 'when-last-login-settings', esc_html__('Settings', 'when-last-login'), __('Settings', 'when-last-login'), 'manage_options', 'when-last-login-settings', array( $this, 'wll_settings_callback' ) );
 
+      add_submenu_page( 'when-last-login-settings', esc_html__('Login Records', 'when-last-login'), __('Login Records', 'when-last-login'), 'manage_options', 'wll-login-records', array( $this, 'wll_login_records_callback' ) );
+
       add_submenu_page( 'when-last-login-settings', esc_html__('Extensions', 'when-last-login'), __('Extensions', 'when-last-login'), 'manage_options', 'admin.php?page=when-last-login-settings&tab=add-ons' );
       
       do_action( 'wll_settings_admin_menu_item' );
 
+    }
+
+    /**
+     * Login records page callback.
+     *
+     * @since  1.3.0
+     */
+    public function wll_login_records_callback() {
+      // Handle bulk delete redirect.
+      if ( ! empty( $_REQUEST['deleted'] ) ) {
+        printf(
+          '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+          sprintf(
+            /* translators: %d: number of records deleted */
+            _n( '%d record deleted.', '%d records deleted.', intval( $_REQUEST['deleted'] ), 'when-last-login' ),
+            intval( $_REQUEST['deleted'] )
+          )
+        );
+      }
+
+      ?>
+      <div class="wrap">
+        <h1><?php esc_html_e( 'Login Records', 'when-last-login' ); ?></h1>
+        <form method="post">
+          <?php
+          $list_table = new WLL_List_Table();
+          $list_table->prepare_items();
+          $list_table->search_box( __( 'Search', 'when-last-login' ), 'wll-records' );
+          $list_table->display();
+          ?>
+        </form>
+      </div>
+      <?php
     }
 
     public function wll_settings_callback(){
@@ -634,7 +590,6 @@ class When_Last_Login {
 
           $wll_settings['user_access'] = isset( $_POST['wll_login_record_user_access'] ) ? sanitize_text_field( $_POST['wll_login_record_user_access'] ) : "";
           $wll_settings['record_ip_address'] = isset( $_POST['wll_record_user_ip_address'] ) && sanitize_text_field( $_POST['wll_record_user_ip_address'] ) == '1'  ? 1 : 0;
-          $wll_settings['show_all_login_records'] = isset( $_POST['wll_all_login_records'] ) && sanitize_text_field( $_POST['wll_all_login_records'] ) == '1'  ? 1 : 0;
 
           $wll_settings = apply_filters( 'wll_settings_filter', $wll_settings );
 
@@ -675,7 +630,7 @@ class When_Last_Login {
     }
 
     /**
-     * Function to remove logs automatically older than 3 months.
+     * Function to remove IP addresses from usermeta.
      * @since 1.0.0
      */
     public function wll_automatically_remove_logs() {
@@ -689,42 +644,6 @@ class When_Last_Login {
       // Bail if not on our settings page
       if ( 'admin.php' == $pagenow && 'when-last-login-settings' != $_GET['page'] ) {
         return;
-      }
-      
-      $sql = "DELETE p, pm FROM $wpdb->posts p LEFT JOIN $wpdb->postmeta pm ON pm.post_id = p.ID WHERE p.post_type = 'wll_records'";
-
-      if ( isset( $_REQUEST['remove_all_wll_records'] ) ) {
-
-        $nonce = $_REQUEST['wll_remove_all_records_nonce'];
-        if ( wp_verify_nonce( $nonce, 'wll_remove_all_records_nonce' ) ) {
-
-          if ( $wpdb->query( $sql ) > 0 ) {
-            add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__success' ) );
-          } else {
-            add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
-          }
-        } else {
-          die( 'nonce not valid.' );
-        }
-      }
-
-      if ( isset( $_REQUEST['remove_wll_records'] ) ) {
-
-        $nonce = $_REQUEST['wll_remove_records_nonce'];
-        if ( wp_verify_nonce( $nonce, 'wll_remove_records_nonce' ) ) {
-
-          $date = apply_filters( 'wll_automatically_remove_logs_date', date( 'Y-m-d', strtotime( '-3 months' ) ) );
-
-          $sql .= " AND p.post_date <= '$date'";
-
-          if ( $wpdb->query( $sql ) > 0 ) {
-            add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__success' ) );
-          } else {
-            add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
-          }
-        } else {
-          die( 'nonce not valid.' );
-        } 
       }
 
       if ( isset( $_REQUEST['remove_wll_ip_addresses'] ) ) {
@@ -742,28 +661,6 @@ class When_Last_Login {
         } else {
           die( 'nonce not valid.' );
         }
-      }
-    }
-
-
-    public function wll_records_columns( $columns ){
-
-      return array_merge( $columns, array( 'wll-ip-address' => __( 'IP Address', 'when-last-login' ) ) );
-
-    }
-
-    public function wll_records_column_contents( $column, $post_id ){
-
-      switch ( $column ) {
-        case 'wll-ip-address':
-          $ip_address = get_post_meta( $post_id, 'wll_user_ip_address', true );
-          if ( ! empty( $ip_address ) && $ip_address != "" ) {
-            echo "<a href='http://www.ip-adress.com/ip_tracer/". esc_attr( $ip_address ) ."' target='_BLANK' title='".__( 'Lookup', 'when-last-login' )."'>" . esc_html( $ip_address ) . "</a>";
-          } else {
-            esc_html_e( 'IP Address Not Recorded', 'when-last-login' );
-          }
-          break;
-
       }
     }
 

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -546,12 +546,12 @@ class When_Last_Login {
      * @since  1.3.0
      */
     public function wll_login_records_callback() {
-      // Process bulk actions and redirect if needed.
+      // Process bulk actions and redirect if needed (before any output).
       $list_table = new WLL_List_Table();
       $deleted = $list_table->process_bulk_action();
 
       if ( $deleted > 0 ) {
-        wp_safe_redirect( add_query_arg( 'deleted', $deleted, admin_url( 'admin.php?page=wll-login-records' ) ) );
+        wp_redirect( add_query_arg( 'deleted', $deleted, admin_url( 'admin.php?page=wll-login-records' ) ) );
         exit;
       }
 

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -50,6 +50,7 @@ class When_Last_Login {
       add_action( 'admin_notices', array( $this, 'update_notice' ) );
 
       add_action( 'wp_ajax_wll_hide_subscription_notice', array( $this, 'wll_hide_subscription_notice' ) );
+      add_action( 'wp_ajax_wll_check_migration_status', array( $this, 'wll_check_migration_status' ) );
 
       //Setting up columns.
       add_filter( 'manage_users_columns', array( $this, 'column_header'), 10, 1 );
@@ -166,6 +167,16 @@ class When_Last_Login {
         wp_die( __( 'Nonce is invalid', 'when-last-login' ) );
       }
       update_option( 'wll_notice_hide', '1' );
+    }
+
+    public function wll_check_migration_status() {
+      if ( ! current_user_can( 'manage_options' ) ) {
+        wp_die( -1 );
+      }
+      $status = get_option( 'wll_migration_status', array() );
+      wp_send_json_success( array(
+        'complete' => empty( $status ) || $status['status'] === 'complete',
+      ) );
     }
 
     public static function load_js_for_notice(){

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -64,7 +64,6 @@ class When_Last_Login {
       add_filter( 'pmpro_memberslist_csv_extra_columns', array( $this, 'pmpro_csv_export_columns' ) );
       add_filter( 'pmpro_memberslist_csv_extra_column_data', array( $this, 'pmpro_csv_export_row' ), 10, 2 );
       add_action( 'admin_menu', array( $this, 'wll_settings_page' ), 9 );
-      add_action( 'admin_menu', array( $this, 'wll_login_records_callback' ), 10 );
       add_action( 'admin_head', array( $this, 'wll_settings_page_head' ) );
       add_action( 'admin_init', array( $this, 'wll_automatically_remove_logs' ) );
 

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -575,7 +575,7 @@ class When_Last_Login {
         <h1><?php esc_html_e( 'Login Records', 'when-last-login' ); ?></h1>
         <?php $list_table->search_box( __( 'Search', 'when-last-login' ), 'wll-records' ); ?>
         <form method="post">
-          <input type="hidden" name="page" value="<?php echo esc_attr( $_REQUEST['page'] ); ?>" />
+          <input type="hidden" name="page" value="<?php echo esc_attr( isset( $_REQUEST['page'] ) ? $_REQUEST['page'] : 'wll-login-records' ); ?>" />
           <?php $list_table->display(); ?>
         </form>
       </div>

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -655,20 +655,70 @@ class When_Last_Login {
 
       if ( isset( $_REQUEST['remove_wll_ip_addresses'] ) ) {
 
-        $nonce = $_REQUEST['wll_remove_ip_nonce'];
-        if ( wp_verify_nonce( $nonce, 'wll_remove_ip_nonce' ) ) {
+          $nonce = $_REQUEST['wll_remove_ip_nonce'];
+          if ( wp_verify_nonce( $nonce, 'wll_remove_ip_nonce' ) ) {
 
-          $sql = "DELETE FROM $wpdb->usermeta WHERE meta_key = 'wll_user_ip_address'";
+            $sql = "DELETE FROM $wpdb->usermeta WHERE meta_key = 'wll_user_ip_address'";
 
-          if ( $wpdb->query( $sql ) > 0 ) {
-            add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__success' ) );
+            if ( $wpdb->query( $sql ) > 0 ) {
+              add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__success' ) );
+            } else {
+              add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
+            }
           } else {
-            add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
+            die( 'nonce not valid.' );
           }
-        } else {
-          die( 'nonce not valid.' );
         }
-      }
+
+        // Remove old login records (90+ days).
+        if ( isset( $_REQUEST['wll_remove_old_records'] ) ) {
+
+          $nonce = isset( $_REQUEST['wll_remove_old_records_nonce'] ) ? sanitize_text_field( $_REQUEST['wll_remove_old_records_nonce'] ) : '';
+          if ( wp_verify_nonce( $nonce, 'wll_remove_old_records_nonce' ) ) {
+            $deleted = WLL_DB::delete_old_records( 90 );
+            if ( $deleted > 0 ) {
+              add_action( 'admin_notices', function() use ( $deleted ) {
+                printf(
+                  '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+                  sprintf(
+                    /* translators: %d: number of records deleted */
+                    esc_html__( '%d old login records deleted.', 'when-last-login' ),
+                    intval( $deleted )
+                  )
+                );
+              } );
+            } else {
+              add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
+            }
+          } else {
+            wp_die( esc_html__( 'Invalid nonce', 'when-last-login' ) );
+          }
+        }
+
+        // Remove all login records.
+        if ( isset( $_REQUEST['wll_remove_all_records'] ) ) {
+
+          $nonce = isset( $_REQUEST['wll_remove_all_records_nonce'] ) ? sanitize_text_field( $_REQUEST['wll_remove_all_records_nonce'] ) : '';
+          if ( wp_verify_nonce( $nonce, 'wll_remove_all_records_nonce' ) ) {
+            $deleted = WLL_DB::delete_all_records();
+            if ( $deleted > 0 ) {
+              add_action( 'admin_notices', function() use ( $deleted ) {
+                printf(
+                  '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+                  sprintf(
+                    /* translators: %d: number of records deleted */
+                    esc_html__( '%d login records deleted.', 'when-last-login' ),
+                    intval( $deleted )
+                  )
+                );
+              } );
+            } else {
+              add_action( 'admin_notices', array( $this, 'wll_remove_records_notice__warning' ) );
+            }
+          } else {
+            wp_die( esc_html__( 'Invalid nonce', 'when-last-login' ) );
+          }
+        }
     }
 
     public function wll_plugin_action_links( $links ) {

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -531,7 +531,8 @@ class When_Last_Login {
 
       add_submenu_page( 'when-last-login-settings', esc_html__('Settings', 'when-last-login'), __('Settings', 'when-last-login'), 'manage_options', 'when-last-login-settings', array( $this, 'wll_settings_callback' ) );
 
-      add_submenu_page( 'when-last-login-settings', esc_html__('Login Records', 'when-last-login'), __('Login Records', 'when-last-login'), 'manage_options', 'wll-login-records', array( $this, 'wll_login_records_callback' ) );
+      $records_hook = add_submenu_page( 'when-last-login-settings', esc_html__('Login Records', 'when-last-login'), __('Login Records', 'when-last-login'), 'manage_options', 'wll-login-records', array( $this, 'wll_login_records_callback' ) );
+      add_action( 'load-' . $records_hook, array( $this, 'wll_login_records_load' ) );
 
       add_submenu_page( 'when-last-login-settings', esc_html__('Extensions', 'when-last-login'), __('Extensions', 'when-last-login'), 'manage_options', 'admin.php?page=when-last-login-settings&tab=add-ons' );
       
@@ -540,12 +541,11 @@ class When_Last_Login {
     }
 
     /**
-     * Login records page callback.
+     * Fires before the login records page renders, allowing redirects.
      *
      * @since  1.3.0
      */
-    public function wll_login_records_callback() {
-      // Process bulk actions and redirect if needed (before any output).
+    public function wll_login_records_load() {
       $list_table = new WLL_List_Table();
       $deleted = $list_table->process_bulk_action();
 
@@ -553,7 +553,14 @@ class When_Last_Login {
         wp_redirect( add_query_arg( 'deleted', $deleted, admin_url( 'admin.php?page=wll-login-records' ) ) );
         exit;
       }
+    }
 
+    /**
+     * Login records page callback.
+     *
+     * @since  1.3.0
+     */
+    public function wll_login_records_callback() {
       // Display success notice after redirect.
       if ( ! empty( $_REQUEST['deleted'] ) ) {
         printf(
@@ -566,6 +573,7 @@ class When_Last_Login {
         );
       }
 
+      $list_table = new WLL_List_Table();
       $list_table->prepare_items();
 
       ?>


### PR DESCRIPTION
## Summary\n\nFixed a potential memory exhaustion issue during the export process. Previously, the code loaded all records into a PHP array before writing them to the file, which could lead to crashes on sites with large datasets.\n\n## Changes\n\n- Refactored export logic to use streaming.\n- Records are now fetched in batches of 500 and written directly to the output buffer ().\n- This ensures constant memory usage regardless of the dataset size.