### PR TITLE
Add WooCommerce wc_last_active user column support

### DIFF
--- a/includes/settings/general.php
+++ b/includes/settings/general.php
@@ -3,6 +3,8 @@
 <?php
 if ( isset( $settings['record_ip_address'] ) && intval( $settings['record_ip_address'] ) == 1 ) { $checked = 1; } else { $checked = 0; }
 $track_all_records = isset( $settings['track_all_records'] ) ? intval( $settings['track_all_records'] ) : 1;
+$show_wc_last_active = isset( $settings['show_wc_last_active'] ) && intval( $settings['show_wc_last_active'] ) == 1;
+$woocommerce_active = class_exists( 'WooCommerce' );
 ?>
 <table class="form-table">
 	<tr>
@@ -21,6 +23,14 @@ $track_all_records = isset( $settings['track_all_records'] ) ? intval( $settings
 			echo esc_html( 'Please enable this option if using the', 'when-last-login' ) . " <a href='https://yoohooplugins.com/plugins/when-last-login-user-statistics/' target='_blank'><strong>" . esc_html( 'When Last Login - User Statistics Add On', 'when-last-login' ) . "</strong></a>";
 		?></small></td>
 	</tr>
+
+	<?php if ( $woocommerce_active ) : ?>
+	<tr>
+		<th><?php esc_html_e( 'Show WooCommerce Last Active', 'when-last-login' ); ?><br></th>
+		<td><input type='checkbox' value='1' name='wll_show_wc_last_active' <?php checked( 1, $show_wc_last_active ); ?>/>
+			<small><?php esc_html_e( 'Display the WooCommerce last active column on the users list. Shows when customers were last active on your store.', 'when-last-login' ); ?></small></td>
+	</tr>
+	<?php endif; ?>
 
 	<?php if ( $track_all_records ) : ?>
 	<tr>

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -438,7 +438,11 @@ class When_Last_Login {
       if ( ! empty( $settings['record_ip_address'] ) ) {
         $column['when_last_login_ip_address'] = esc_html__( 'IP Address', 'when-last-login' );
       }
-      
+
+      // Add WooCommerce Last Active column if enabled and WooCommerce is active
+      if ( ! empty( $settings['show_wc_last_active'] ) && class_exists( 'WooCommerce' ) ) {
+        $column['wc_last_active'] = esc_html__( 'WC Last Active', 'when-last-login' );
+      }
 
        return $column;
      }
@@ -472,6 +476,17 @@ class When_Last_Login {
           }
 
 
+        } else if( $column_name == 'wc_last_active' ){
+          // WooCommerce Last Active column
+          if ( class_exists( 'WooCommerce' ) ) {
+            $wc_last_active = get_user_meta( $id, 'wc_last_active', true );
+            if ( ! empty( $wc_last_active ) ) {
+              return human_time_diff( $wc_last_active );
+            } else {
+              return esc_html__( 'Never', 'when-last-login' );
+            }
+          }
+          return '';
         }
       return $value;
      }
@@ -639,6 +654,7 @@ class When_Last_Login {
           $wll_settings['user_access'] = isset( $_POST['wll_login_record_user_access'] ) ? sanitize_text_field( $_POST['wll_login_record_user_access'] ) : "";
           $wll_settings['record_ip_address'] = isset( $_POST['wll_record_user_ip_address'] ) && sanitize_text_field( $_POST['wll_record_user_ip_address'] ) == '1'  ? 1 : 0;
           $wll_settings['track_all_records'] = isset( $_POST['wll_track_all_records'] ) && sanitize_text_field( $_POST['wll_track_all_records'] ) == '1' ? 1 : 0;
+          $wll_settings['show_wc_last_active'] = isset( $_POST['wll_show_wc_last_active'] ) && sanitize_text_field( $_POST['wll_show_wc_last_active'] ) == '1' ? 1 : 0;
 
           $wll_settings = apply_filters( 'wll_settings_filter', $wll_settings );
 


### PR DESCRIPTION
## Summary

This PR adds support for displaying WooCommerce's native `wc_last_active` user meta field as an optional column on the WordPress Users list table, addressing the feature request from the [WordPress.org support forums](https://wordpress.org/support/topic/suggestion-include-wc_last_active-user-meta-field/).

## Changes

### Settings
- New option: **Show WooCommerce Last Active** (checkbox)
- Only visible when WooCommerce is active
- Stored in `wll_settings['show_wc_last_active']`

### User Column
- Column header: "WC Last Active"
- Displays `wc_last_active` user meta in human-readable format (e.g., "2 days ago")
- Shows "Never" for users without WooCommerce activity
- Only appears when:
  1. Setting is enabled
  2. WooCommerce plugin is active

## Benefits

- Provides additional insight alongside the existing Last Login column
- Leverages WooCommerce's existing activity tracking
- Non-intrusive: disabled by default, requires explicit opt-in
- Works with WooCommerce's native data - no additional storage needed

## Testing

1. Activate WooCommerce
2. Enable the "Show WooCommerce Last Active" setting
3. Visit Users list
4. Verify "WC Last Active" column appears
5. Verify values display correctly for users with WooCommerce activity

## Screenshot

The setting appears under Options on the When Last Login settings page when WooCommerce is active.