### PR TITLE
Fix: Code review issues - output escaping, nonce hardening, migration safety

### DIFF
--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -528,7 +528,7 @@ class WLL_DB {
 
 		$status = get_option( 'wll_migration_status', array() );
 
-		if ( empty( $status ) || $status['status'] === 'complete' ) {
+		if ( empty( $status ) || ! isset( $status['status'] ) || $status['status'] === 'complete' ) {
 			return;
 		}
 
@@ -876,7 +876,7 @@ class WLL_DB {
 	public static function cleanup_migrated_posts() {
 		$migration_status = get_option( 'wll_migration_status', array() );
 
-		if ( empty( $migration_status ) || $migration_status['status'] !== 'complete' ) {
+		if ( empty( $migration_status ) || ! isset( $migration_status['status'] ) || $migration_status['status'] !== 'complete' ) {
 			return 0;
 		}
 

--- a/includes/privacy-policy.php
+++ b/includes/privacy-policy.php
@@ -145,7 +145,7 @@ function plugin_user_data_eraser( $email_address, $page = 1 ) {
 		if ( $deleted_when_last_login ) {
 			$items_removed = true;
 		} else {
-			$messages[] = __( 'Your last login timestamp was unable to be removed at this time.', 'when-last-login' );
+			$messages[] = esc_html__( 'Your last login timestamp was unable to be removed at this time.', 'when-last-login' );
 			$items_retained = true;
 		}
 		

--- a/includes/settings/general.php
+++ b/includes/settings/general.php
@@ -20,7 +20,7 @@ $woocommerce_active = class_exists( 'WooCommerce' );
 		<th><?php esc_html_e( 'Enable All Login Records', 'when-last-login' ); ?><br></th>
 		<td><input type='checkbox' value='1' name='wll_track_all_records' <?php checked( 1, $track_all_records ); ?>/>
 			<small><?php 
-			echo esc_html( 'Please enable this option if using the', 'when-last-login' ) . " <a href='https://yoohooplugins.com/plugins/when-last-login-user-statistics/' target='_blank'><strong>" . esc_html( 'When Last Login - User Statistics Add On', 'when-last-login' ) . "</strong></a>";
+			echo esc_html( 'Please enable this option if using the', 'when-last-login' ) . " <a href='" . esc_url( 'https://yoohooplugins.com/plugins/when-last-login-user-statistics/' ) . "' target='_blank'><strong>" . esc_html( 'When Last Login - User Statistics Add On', 'when-last-login' ) . "</strong></a>";
 		?></small></td>
 	</tr>
 
@@ -47,18 +47,18 @@ $woocommerce_active = class_exists( 'WooCommerce' );
 	?>
 	<script>
 		function wll_remove_old_records(){
-			if( window.confirm('<?php echo $old_records_message; ?>')) {
-				window.location.href = "<?php echo add_query_arg( array( 'wll_remove_old_records' => '1', 'wll_remove_old_records_nonce' => $remove_old_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
+			if( window.confirm('<?php echo esc_js( $old_records_message ); ?>')) {
+				window.location.href = "<?php echo esc_js( add_query_arg( array( 'wll_remove_old_records' => '1', 'wll_remove_old_records_nonce' => $remove_old_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ) ); ?>";
 			}
 		}
 		function wll_remove_all_records(){
-			if( window.confirm('<?php echo $all_records_message; ?>')) {
-				window.location.href = "<?php echo add_query_arg( array( 'wll_remove_all_records' => '1', 'wll_remove_all_records_nonce' => $remove_all_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
+			if( window.confirm('<?php echo esc_js( $all_records_message ); ?>')) {
+				window.location.href = "<?php echo esc_js( add_query_arg( array( 'wll_remove_all_records' => '1', 'wll_remove_all_records_nonce' => $remove_all_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ) ); ?>";
 			}
 		}
 		function wll_remove_all_ips(){
-			if( window.confirm('<?php echo $all_ip_message; ?>')) {
-				window.location.href = "<?php echo add_query_arg( array( 'remove_wll_ip_addresses' => '1', 'wll_remove_ip_nonce' => $remove_ip_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ); ?>";
+			if( window.confirm('<?php echo esc_js( $all_ip_message ); ?>')) {
+				window.location.href = "<?php echo esc_js( add_query_arg( array( 'remove_wll_ip_addresses' => '1', 'wll_remove_ip_nonce' => $remove_ip_nonce ), admin_url( 'admin.php?page=when-last-login-settings' ) ) ); ?>";
 			}
 		}
 	</script>

--- a/includes/updates/upgrade-1.3.0.php
+++ b/includes/updates/upgrade-1.3.0.php
@@ -200,7 +200,7 @@ function wll_migrate_records_batch() {
 
 	$status = get_option( 'wll_migration_status', array() );
 
-	if ( empty( $status ) || $status['status'] === 'complete' ) {
+	if ( empty( $status ) || ! isset( $status['status'] ) || $status['status'] === 'complete' ) {
 		return;
 	}
 

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -169,7 +169,7 @@ class When_Last_Login {
       if ( ! current_user_can( 'manage_options' ) ) {
         wp_die( -1 );
       }
-      if ( ! wp_verify_nonce( $_POST['nonce'], 'wll_hide_notice_nonce' ) ) {
+      if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( $_POST['nonce'], 'wll_hide_notice_nonce' ) ) {
         wp_die( __( 'Nonce is invalid', 'when-last-login' ) );
       }
       update_option( 'wll_notice_hide', '1' );
@@ -400,7 +400,7 @@ class When_Last_Login {
                 $count = 1;
                 
                 foreach($topusers as $wllusers){
-                    echo '<tr><td>' . intval( $count ) . '</td>';
+                    echo '<tr><td>' . esc_html( intval( $count ) ) . '</td>';
                     echo '<td>' . esc_html( $wllusers->display_name ) . '</td>';
                     echo '<td>' . esc_html( get_user_meta( $wllusers->ID, 'when_last_login_count', true ) ) . '</td>';
                     echo '<td>' . esc_html( wp_date( 'Y-m-d H:i:s', get_user_meta( $wllusers->ID, 'when_last_login', true ) ) ) . '</td></tr>';
@@ -474,7 +474,7 @@ class When_Last_Login {
           $when_last_login_ip_address = get_user_meta( $id, 'wll_user_ip_address', true );
 
           if ( ! empty( $when_last_login_ip_address ) && ! empty( $settings['record_ip_address'] ) ) {
-            return "<a href='https://www.ip-adress.com/ip_tracer/". esc_attr( $when_last_login_ip_address ) ."' target='_BLANK' title='".__( 'Lookup', 'when-last-login' )."'>" . esc_html( $when_last_login_ip_address ) . "</a>";
+            return "<a href='" . esc_url( 'https://www.ip-adress.com/ip_tracer/' . $when_last_login_ip_address ) . "' target='_BLANK' title='" . esc_attr__( 'Lookup', 'when-last-login' ) . "'>" . esc_html( $when_last_login_ip_address ) . "</a>";
           } else {
             return esc_html__( 'IP Address Not Recorded', 'when-last-login' );
           }
@@ -661,7 +661,7 @@ class When_Last_Login {
 
       if( isset( $_POST['wll_save_settings'] ) ){
 
-        if( wp_verify_nonce( $_POST['_nonce'], 'wll_settings_nonce' ) ) {
+        if( isset( $_POST['_nonce'] ) && wp_verify_nonce( $_POST['_nonce'], 'wll_settings_nonce' ) ) {
 
           $wll_settings['user_access'] = isset( $_POST['wll_login_record_user_access'] ) ? sanitize_text_field( $_POST['wll_login_record_user_access'] ) : "";
           $wll_settings['record_ip_address'] = isset( $_POST['wll_record_user_ip_address'] ) && sanitize_text_field( $_POST['wll_record_user_ip_address'] ) == '1'  ? 1 : 0;
@@ -730,8 +730,8 @@ class When_Last_Login {
 
       if ( isset( $_REQUEST['remove_wll_ip_addresses'] ) ) {
 
-          $nonce = $_REQUEST['wll_remove_ip_nonce'];
-          if ( wp_verify_nonce( $nonce, 'wll_remove_ip_nonce' ) ) {
+          $nonce = isset( $_REQUEST['wll_remove_ip_nonce'] ) ? sanitize_text_field( $_REQUEST['wll_remove_ip_nonce'] ) : '';
+          if ( $nonce && wp_verify_nonce( $nonce, 'wll_remove_ip_nonce' ) ) {
 
             $result = $wpdb->query( $wpdb->prepare( "DELETE FROM {$wpdb->usermeta} WHERE meta_key = %s", 'wll_user_ip_address' ) );
 


### PR DESCRIPTION
## Summary

This PR applies a round of code-review fixes to harden output escaping, nonce validation, and migration safety in the When Last Login plugin.

## Changes

### Output escaping
- **Dashboard widget (non-network)**: Escape the row count with `esc_html()` (network version already did this).
- **IP lookup link**: Use `esc_url()` for the IP tracer URL and `esc_attr__()` for the link title instead of mixing `esc_attr()`/unescaped `__()`.
- **Settings page inline JS**: Escape the `window.confirm()` messages and redirect URLs with `esc_js()`.
- **Add-ons link**: Escape the hardcoded add-on URL with `esc_url()`.
- **Privacy eraser**: Use `esc_html__()` for the "unable to be removed" message.

### Nonce / input hardening
- Add `isset()` guards before `wp_verify_nonce()` in the subscription-notice AJAX handler, settings save handler, and IP-removal handler.
- Sanitize and validate the IP-removal nonce before verifying it.

### Migration safety
- Guard against undefined `status` index in `WLL_DB::migrate_batch()`, `WLL_DB::cleanup_migrated_posts()`, and `wll_migrate_records_batch()` to avoid PHP warnings.

## Testing
- No PHP runtime available in this environment; changes are syntax-reviewed manually.
- All changes are conservative escaping/hardening with no logic or behavior changes.
