### PR TITLE
Fix: Security hardening - ABSPATH guards and output escaping

### DIFF
--- a/includes/privacy-policy.php
+++ b/includes/privacy-policy.php
@@ -1,5 +1,9 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 /*
  * Code to support GDPR compliances, WordPress version 4.9.6+
  * @since 1.1

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -1,4 +1,13 @@
 <?php
+/**
+ * Settings page template for When Last Login.
+ *
+ * @package When_Last_Login
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 
 $tabs = array(
 	'general' => array(
@@ -14,7 +23,7 @@ $tabs = array(
 $tabs = apply_filters( 'wll_settings_page_tabs', $tabs );
 
 $wll_migration_status = get_option( 'wll_migration_status', array() );
-$wll_migration_active = ! empty( $wll_migration_status ) && $wll_migration_status['status'] !== 'complete';
+$wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migration_status['status'] ) && $wll_migration_status['status'] !== 'complete';
 
 ?>
 
@@ -39,7 +48,7 @@ $wll_migration_active = ! empty( $wll_migration_status ) && $wll_migration_statu
 <?php endif; ?>
 
 <div id="wll-setting-header">
-	<img src="<?php echo WLL_PLUGIN . '/includes/images/whenlastlogin.png'; ?>" width="300px" height="auto" style="margin-top:2%;"/><span style="position:relative;top:-15px;"><?php echo 'v' . WLL_VER; ?></span>
+	<img src="<?php echo esc_url( WLL_PLUGIN . '/includes/images/whenlastlogin.png' ); ?>" width="300px" height="auto" style="margin-top:2%;"/><span style="position:relative;top:-15px;"><?php echo esc_html( 'v' . WLL_VER ); ?></span>
 </div>
 <div class='wrap'>
 

--- a/includes/settings/add-ons.php
+++ b/includes/settings/add-ons.php
@@ -1,4 +1,8 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
 /**
  * Add-ons / Extensions page for When Last Login.
  *

--- a/includes/settings/general.php
+++ b/includes/settings/general.php
@@ -1,6 +1,16 @@
-<?php $settings = get_option( 'wll_settings' ); ?>
-
 <?php
+/**
+ * General settings tab for When Last Login.
+ *
+ * @package When_Last_Login
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+$settings = get_option( 'wll_settings' );
+
 if ( isset( $settings['record_ip_address'] ) && intval( $settings['record_ip_address'] ) == 1 ) { $checked = 1; } else { $checked = 0; }
 $track_all_records = isset( $settings['track_all_records'] ) ? intval( $settings['track_all_records'] ) : 1;
 $show_wc_last_active = isset( $settings['show_wc_last_active'] ) && intval( $settings['show_wc_last_active'] ) == 1;

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -10,6 +10,10 @@ Text Domain: when-last-login
 Domain Path: /languages
 */
 
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
 use geertw\IpAnonymizer\IpAnonymizer;
 
 define( 'WLL_VER', '1.3.0' );


### PR DESCRIPTION
## Summary

This PR applies additional security hardening following the code review of the `dev` branch.

## Changes

### ABSPATH Guards
- Add direct access protection to all PHP files:
  - `when-last-login.php` (main plugin file)
  - `includes/settings.php`
  - `includes/settings/general.php`
  - `includes/settings/add-ons.php`
  - `includes/privacy-policy.php`

### Output Escaping
- Fix unescaped image URL in settings header: `esc_url()`
- Fix unescaped version output: `esc_html()`

### Undefined Index Fix
- Add `isset()` guard for `wll_migration_status['status']` in `settings.php`
- Same pattern as PR #70 fix applied to migration files

## Testing
- All changes are static hardening with no functional changes
- Syntax verified manually

## Related
Follow-up to PR #70