### PR TITLE
fix: resolve data migration issues

### DIFF
--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -460,40 +460,59 @@ class WLL_DB {
 
 		$summary_table = self::get_table_name( self::SUMMARY_TABLE );
 
-		// Get all users with login data.
-		$users = get_users( array(
-			'meta_key'     => 'when_last_login',
-			'meta_compare' => 'EXISTS',
-			'fields'       => array( 'ID' ),
-			'number'       => 1000,
-		) );
+		// Ensure batch size constant is defined.
+		$batch_size = defined( 'WLL_BATCH_SIZE' ) ? WLL_BATCH_SIZE : 500;
 
-		foreach ( $users as $user ) {
-			$last_login = get_user_meta( $user->ID, 'when_last_login', true );
-			$login_count = get_user_meta( $user->ID, 'when_last_login_count', true );
+		// Use offset-based pagination for reliability.
+		$offset = 0;
 
-			if ( empty( $last_login ) ) {
-				continue;
+		while ( true ) {
+			$users = get_users( array(
+				'meta_key'     => 'when_last_login',
+				'meta_compare' => 'EXISTS',
+				'fields'       => array( 'ID' ),
+				'number'       => $batch_size,
+				'offset'       => $offset,
+			) );
+
+			if ( empty( $users ) ) {
+				break;
 			}
 
-			// Convert timestamp to datetime.
-			$login_time = is_numeric( $last_login )
-				? gmdate( 'Y-m-d H:i:s', $last_login )
-				: $last_login;
+			foreach ( $users as $user ) {
+				$last_login = get_user_meta( $user->ID, 'when_last_login', true );
+				$login_count = get_user_meta( $user->ID, 'when_last_login_count', true );
 
-			// Upsert into summary table.
-			$wpdb->query(
-				$wpdb->prepare(
-					"INSERT INTO $summary_table (user_id, last_login, login_count)
-					 VALUES (%d, %s, %d)
-					 ON DUPLICATE KEY UPDATE
-					 last_login = VALUES(last_login),
-					 login_count = VALUES(login_count)",
-					$user->ID,
-					$login_time,
-					absint( $login_count ) ?: 1
-				)
-			);
+				if ( empty( $last_login ) ) {
+					continue;
+				}
+
+				// Convert timestamp to datetime.
+				$login_time = is_numeric( $last_login )
+					? gmdate( 'Y-m-d H:i:s', $last_login )
+					: $last_login;
+
+				// Upsert into summary table.
+				$wpdb->query(
+					$wpdb->prepare(
+						"INSERT INTO $summary_table (user_id, last_login, login_count)
+						 VALUES (%d, %s, %d)
+						 ON DUPLICATE KEY UPDATE
+						 last_login = VALUES(last_login),
+						 login_count = VALUES(login_count)",
+						$user->ID,
+						$login_time,
+						absint( $login_count ) ?: 1
+					)
+				);
+			}
+
+			$offset += $batch_size;
+
+			// Prevent timeout on large sites.
+			if ( 0 === ( $offset / $batch_size ) % 10 ) {
+				sleep( 1 );
+			}
 		}
 	}
 
@@ -532,7 +551,15 @@ class WLL_DB {
 			return;
 		}
 
-		$batch_size = apply_filters( 'wll_migration_batch_size', WLL_BATCH_SIZE * 2 );
+		// Check migration lock to prevent concurrent runs.
+		if ( get_transient( 'wll_migration_lock' ) ) {
+			return;
+		}
+		set_transient( 'wll_migration_lock', true, 5 * MINUTE_IN_SECONDS );
+
+		// Ensure batch size constant is defined.
+		$default_batch = defined( 'WLL_BATCH_SIZE' ) ? WLL_BATCH_SIZE : 500;
+		$batch_size = apply_filters( 'wll_migration_batch_size', $default_batch * 2 );
 
 		// Direct SQL avoids WP_Query overhead (filters, object cache, extra joins).
 		$post_ids = $wpdb->get_col(
@@ -621,6 +648,9 @@ class WLL_DB {
 			$status['completed'] = current_time( 'mysql' );
 			update_option( 'wll_migration_status', $status );
 		}
+
+		// Release lock after batch.
+		delete_transient( 'wll_migration_lock' );
 	}
 
 	/**

--- a/includes/updates/upgrade-1.3.0.php
+++ b/includes/updates/upgrade-1.3.0.php
@@ -81,6 +81,9 @@ function wll_upgrade_1_3_0() {
 	// Populate summary table from existing user meta.
 	wll_populate_summary_from_user_meta();
 
+	// Set migration lock to prevent race conditions.
+	set_transient( 'wll_migration_lock', true, 5 * MINUTE_IN_SECONDS );
+
 	// Count posts to migrate.
 	$args = array(
 		'post_type'      => 'wll_records',
@@ -118,6 +121,9 @@ function wll_upgrade_1_3_0() {
 	// Update database version.
 	update_option( 'wll_db_version', '1.3.0' );
 
+	// Release lock after upgrade completes.
+	delete_transient( 'wll_migration_lock' );
+
 	/**
 	 * Fires after 1.3.0 upgrade completes.
 	 *
@@ -136,26 +142,29 @@ function wll_populate_summary_from_user_meta() {
 
 	$summary_table = $wpdb->prefix . 'when_last_login';
 
-	// Get all users with login data in batches.
+	// Ensure batch size constant is defined.
+	$batch_size = defined( 'WLL_BATCH_SIZE' ) ? WLL_BATCH_SIZE : 500;
+
+	// Use offset-based pagination for reliability.
+	$offset = 0;
+
+	while ( true ) {
 		$args = array(
 			'meta_key'     => 'when_last_login',
 			'meta_compare' => 'EXISTS',
 			'fields'       => array( 'ID' ),
-			'number'       => WLL_BATCH_SIZE,
+			'number'       => $batch_size,
+			'offset'       => $offset,
 		);
+		$users = get_users( $args );
 
-		$page = 1;
-		while ( true ) {
-			$args['paged'] = $page;
-			$users = get_users( $args );
-
-			if ( empty( $users ) ) {
-				break;
-			}
+		if ( empty( $users ) ) {
+			break;
+		}
 
 		foreach ( $users as $user ) {
 			$last_login_ts = get_user_meta( $user->ID, 'when_last_login', true );
-			$login_count    = get_user_meta( $user->ID, 'when_last_login_count', true );
+			$login_count = get_user_meta( $user->ID, 'when_last_login_count', true );
 
 			if ( empty( $last_login_ts ) ) {
 				continue;
@@ -181,10 +190,10 @@ function wll_populate_summary_from_user_meta() {
 			);
 		}
 
-		$page++;
+		$offset += $batch_size;
 
 		// Prevent timeout on large sites.
-		if ( 0 === $page % 10 ) {
+		if ( 0 === ( $offset / $batch_size ) % 10 ) {
 			sleep( 1 );
 		}
 	}
@@ -204,7 +213,15 @@ function wll_migrate_records_batch() {
 		return;
 	}
 
-	$batch_size = apply_filters( 'wll_migration_batch_size', WLL_BATCH_SIZE );
+	// Check migration lock to prevent concurrent runs.
+	if ( get_transient( 'wll_migration_lock' ) ) {
+		return;
+	}
+	set_transient( 'wll_migration_lock', true, 5 * MINUTE_IN_SECONDS );
+
+	// Ensure batch size constant is defined.
+	$default_batch = defined( 'WLL_BATCH_SIZE' ) ? WLL_BATCH_SIZE : 500;
+	$batch_size = apply_filters( 'wll_migration_batch_size', $default_batch );
 	$records_table = $wpdb->prefix . 'wll_login_records';
 
 	$args = array(


### PR DESCRIPTION
## Summary
Fixes critical issues in the 1.3.0 data migration code.

## Changes
- **Migration Locking**: Added transient-based lock to prevent concurrent migrations and race conditions
- **Batch Size Fallback**: Added fallback for `WLL_BATCH_SIZE` constant if not defined
- **Pagination Fix**: Changed from `paged` to `offset`-based pagination for reliability
- **Complete Migration**: Removed 1000 user limit - now processes all users
- **Timeout Prevention**: Added sleep every 10 batches for large sites

## Files Changed
- `includes/updates/upgrade-1.3.0.php`
- `includes/class-wll-db.php`

## Testing
- Syntax validated with `php -l`
- Ready for testing on large installs