### PR TITLE
feat: add streamline mode to hide admin UI

### DIFF
--- a/includes/settings/general.php
+++ b/includes/settings/general.php
@@ -14,6 +14,7 @@ $settings = get_option( 'wll_settings' );
 if ( isset( $settings['record_ip_address'] ) && intval( $settings['record_ip_address'] ) == 1 ) { $checked = 1; } else { $checked = 0; }
 $track_all_records = isset( $settings['track_all_records'] ) ? intval( $settings['track_all_records'] ) : 1;
 $show_wc_last_active = isset( $settings['show_wc_last_active'] ) && intval( $settings['show_wc_last_active'] ) == 1;
+$hide_admin_menu = isset( $settings['hide_admin_menu'] ) && intval( $settings['hide_admin_menu'] ) == 1;
 $woocommerce_active = class_exists( 'WooCommerce' );
 ?>
 <table class="form-table">
@@ -41,6 +42,11 @@ $woocommerce_active = class_exists( 'WooCommerce' );
 			<small><?php esc_html_e( 'Display the WooCommerce last active column on the users list. Shows when customers were last active on your store.', 'when-last-login' ); ?></small></td>
 	</tr>
 	<?php endif; ?>
+	<tr>
+		<th><?php esc_html_e( 'Hide Admin Menu (Streamline Mode)', 'when-last-login' ); ?><br></th>
+		<td><input type='checkbox' value='1' name='wll_hide_admin_menu' <?php checked( 1, $hide_admin_menu ); ?>/>
+			<small><?php esc_html_e( 'Hide the WLL admin menu and dashboard widget. Login tracking continues in the background. Users list column still shows last login data.', 'when-last-login' ); ?></small></td>
+	</tr>
 
 	<?php if ( $track_all_records ) : ?>
 	<tr>

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -54,9 +54,13 @@ class When_Last_Login {
       add_action( 'user_register', array( $this, 'wll_user_register' ), 10, 1 );
       add_action( 'two_factor_user_authenticated', array( $this, 'two_factor_user_authenticated' ), 10, 2 );
 
-      //Admin actions
-      add_action( 'wp_dashboard_setup', array( $this, 'admin_dashboard_widget' ) );      
-      add_action( 'admin_notices', array( $this, 'update_notice' ) );
+      //Admin actions - only load if not in streamline mode
+      $hide_admin = isset( $settings['hide_admin_menu'] ) && intval( $settings['hide_admin_menu'] ) === 1;
+
+      if ( ! $hide_admin ) {
+        add_action( 'wp_dashboard_setup', array( $this, 'admin_dashboard_widget' ) );
+        add_action( 'admin_notices', array( $this, 'update_notice' ) );
+      }
 
       add_action( 'wp_ajax_wll_hide_subscription_notice', array( $this, 'wll_hide_subscription_notice' ) );
       add_action( 'wp_ajax_wll_check_migration_status', array( $this, 'wll_check_migration_status' ) );
@@ -72,12 +76,13 @@ class When_Last_Login {
       add_action( 'pmpro_memberslist_extra_cols_body', array( $this, 'pmpro_memberlist_add_column_data' ) );
       add_filter( 'pmpro_memberslist_csv_extra_columns', array( $this, 'pmpro_csv_export_columns' ) );
       add_filter( 'pmpro_memberslist_csv_extra_column_data', array( $this, 'pmpro_csv_export_row' ), 10, 2 );
-      add_action( 'admin_menu', array( $this, 'wll_settings_page' ), 9 );
-      add_action( 'admin_head', array( $this, 'wll_settings_page_head' ) );
-      add_action( 'admin_init', array( $this, 'wll_automatically_remove_logs' ) );
-
-      add_filter( 'plugin_row_meta', array( $this, 'wll_plugin_row_meta' ), 10, 2 );
-      add_filter( 'plugin_action_links_' . WLL_BASENAME, array( $this, 'wll_plugin_action_links' ), 10, 2 );
+      if ( ! $hide_admin ) {
+        add_action( 'admin_menu', array( $this, 'wll_settings_page' ), 9 );
+        add_action( 'admin_head', array( $this, 'wll_settings_page_head' ) );
+        add_action( 'admin_init', array( $this, 'wll_automatically_remove_logs' ) );
+        add_filter( 'plugin_row_meta', array( $this, 'wll_plugin_row_meta' ), 10, 2 );
+        add_filter( 'plugin_action_links_' . WLL_BASENAME, array( $this, 'wll_plugin_action_links' ), 10, 2 );
+      }
 
       /**
       * Multisite support
@@ -671,6 +676,7 @@ class When_Last_Login {
           $wll_settings['record_ip_address'] = isset( $_POST['wll_record_user_ip_address'] ) && sanitize_text_field( $_POST['wll_record_user_ip_address'] ) == '1'  ? 1 : 0;
           $wll_settings['track_all_records'] = isset( $_POST['wll_track_all_records'] ) && sanitize_text_field( $_POST['wll_track_all_records'] ) == '1' ? 1 : 0;
           $wll_settings['show_wc_last_active'] = isset( $_POST['wll_show_wc_last_active'] ) && sanitize_text_field( $_POST['wll_show_wc_last_active'] ) == '1' ? 1 : 0;
+          $wll_settings['hide_admin_menu'] = isset( $_POST['wll_hide_admin_menu'] ) && sanitize_text_field( $_POST['wll_hide_admin_menu'] ) == '1' ? 1 : 0;
 
           $wll_settings = apply_filters( 'wll_settings_filter', $wll_settings );
 


### PR DESCRIPTION
## Summary
Adds a Hide Admin Menu (Streamline Mode) option to run WLL in the background without the admin UI.

## Changes
- New Setting: hide_admin_menu checkbox in General settings
- Conditional Hooks: Admin UI hooks only load when streamline mode is off
- Core Tracking: Login tracking, user columns, PMPro integration continue working

## What's Hidden in Streamline Mode
- Admin menu (Settings, Login Records, Add Ons)
- Dashboard widget
- Admin notices
- Plugin row meta and action links
- Automatic log cleanup (intentionally disabled)

## What Still Works
- Login tracking on every wp_login
- User registration tracking
- 2FA authentication tracking
- Last Login column in Users list
- Column sorting by login date
- PMPro member list integration
- Background data storage

## Testing
- Syntax validation passed
- Ready for manual testing on test site