### PR TITLE
Fix: redirect after settings save so menu/notice reflect new state

### DIFF
--- a/when-last-login.php
+++ b/when-last-login.php
@@ -82,8 +82,9 @@ class When_Last_Login {
         //Streamline mode: still expose the settings under Settings > When Last Login so it can be turned back off.
         add_action( 'admin_menu', array( $this, 'wll_settings_page_streamlined' ), 9 );
       }
-      add_action( 'admin_head', array( $this, 'wll_settings_page_head' ) );
+      add_action( 'admin_init', array( $this, 'wll_settings_page_head' ) );
       add_action( 'admin_init', array( $this, 'wll_automatically_remove_logs' ) );
+      add_action( 'admin_notices', array( $this, 'wll_admin_notices' ) );
       add_filter( 'plugin_row_meta', array( $this, 'wll_plugin_row_meta' ), 10, 2 );
       add_filter( 'plugin_action_links_' . WLL_BASENAME, array( $this, 'wll_plugin_action_links' ), 10, 2 );
 
@@ -681,12 +682,15 @@ class When_Last_Login {
 
     public function wll_settings_page_head(){
 
-      $wll_settings = array();
+      if ( empty( $_GET['page'] ) || 'when-last-login-settings' !== $_GET['page'] ) {
+        return;
+      }
 
       if( isset( $_POST['wll_save_settings'] ) ){
 
         if( isset( $_POST['_nonce'] ) && wp_verify_nonce( $_POST['_nonce'], 'wll_settings_nonce' ) ) {
 
+          $wll_settings = array();
           $wll_settings['user_access'] = isset( $_POST['wll_login_record_user_access'] ) ? sanitize_text_field( $_POST['wll_login_record_user_access'] ) : "";
           $wll_settings['record_ip_address'] = isset( $_POST['wll_record_user_ip_address'] ) && sanitize_text_field( $_POST['wll_record_user_ip_address'] ) == '1'  ? 1 : 0;
           $wll_settings['track_all_records'] = isset( $_POST['wll_track_all_records'] ) && sanitize_text_field( $_POST['wll_track_all_records'] ) == '1' ? 1 : 0;
@@ -695,10 +699,20 @@ class When_Last_Login {
 
           $wll_settings = apply_filters( 'wll_settings_filter', $wll_settings );
 
-          if ( update_option( 'wll_settings', $wll_settings ) ) {
-            //show admin notice here.
-            add_action( 'admin_notices', array( $this, 'wll_admin_notices' ) );
+          update_option( 'wll_settings', $wll_settings );
+
+          //Redirect back (rather than just rendering) so the admin menu, dashboard widget, and
+          //notice all reflect the freshly-saved settings on a real page load - this matters most
+          //for hide_admin_menu, since that changes which menu registers on 'admin_menu'.
+          $redirect_args = array(
+            'page' => 'when-last-login-settings',
+            'wll-settings-updated' => '1',
+          );
+          if ( ! empty( $_GET['tab'] ) ) {
+            $redirect_args['tab'] = sanitize_text_field( $_GET['tab'] );
           }
+          wp_safe_redirect( add_query_arg( $redirect_args, admin_url( 'admin.php' ) ) );
+          exit;
         } else {
           wp_die( esc_html__( 'Nonce is not valid', 'when-last-login' ) );
         }
@@ -708,6 +722,10 @@ class When_Last_Login {
     }
 
     public function wll_admin_notices() {
+
+      if ( empty( $_GET['wll-settings-updated'] ) ) {
+        return;
+      }
     ?>
       <div class="notice notice-success is-dismissible">
         <p><?php esc_html_e( 'Settings saved successfully.', 'when-last-login' ); ?></p>


### PR DESCRIPTION
## Summary
- The settings-save handler ran on `admin_head`, which fires after the admin menu is already built and page output has started. So when toggling "Hide Admin Menu (Streamline Mode)" (or any other setting), the same-request response still showed the old menu/dashboard-widget state - it looked broken until a manual second page load.
- Moves the save handler from `admin_head` to `admin_init`, gated to the settings page (`page=when-last-login-settings`), and does a redirect back to the settings page after a successful save (POST/Redirect/GET), so the admin menu, dashboard widget, and success notice all reflect the freshly-saved settings on a real page load.
- The "Settings saved successfully" notice is now driven by a `wll-settings-updated` query arg set on that redirect, rather than being conditionally hooked mid-request.

## Test plan
- [ ] Toggle "Hide Admin Menu (Streamline Mode)" on, save, and confirm the page reloads with the top-level menu gone and "When Last Login" now under Settings (no stale UI, no extra manual refresh needed).
- [ ] Toggle it back off from the Settings-nested page and confirm the page reloads with the top-level menu restored.
- [ ] Save any other setting (IP address recording, login records, WooCommerce column) and confirm the "Settings saved successfully" notice still appears after redirect.
- [ ] Confirm saving from a specific tab (e.g. `&tab=general`) redirects back to that same tab.

Generated with Claude Code
