### PR TITLE
Fix: tab active-state so only one tab highlights at a time

### DIFF
--- a/includes/settings.php
+++ b/includes/settings.php
@@ -59,19 +59,13 @@ $wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migratio
 </div>
 <div class='wrap'>
 
+	<?php $current_tab = isset( $_GET['tab'] ) ? $_GET['tab'] : 'general'; ?>
+
 	<h2 class="nav-tab-wrapper"><?php
 
 	foreach( $tabs as $key => $val ){
-		
-		$active = '';
 
-		if( isset( $_GET['tab'] ) && $_GET['tab'] == $key ){
-			$active = 'nav-tab-active';
-		} else {
-			if( $key == 'general' ){
-				$active = 'nav-tab-active';
-			}
-		}
+		$active = ( $current_tab == $key ) ? 'nav-tab-active' : '';
 
 		echo '<a class="nav-tab ' . esc_attr( $active ) . '" href="?page=when-last-login-settings&tab=' . esc_attr( $key ) . '">' . esc_html( $val['title'] ) . '</a>';
 
@@ -96,12 +90,6 @@ $wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migratio
 		);
 
 		$content = apply_filters( 'wll_settings_page_content', $content );
-
-		if( isset( $_GET['tab'] ) ){
-			$current_tab = $_GET['tab'];
-		} else {
-			$current_tab = 'general';
-		}
 
 		foreach( $content as $key => $val ){
 


### PR DESCRIPTION
## Summary
- The nav-tab active-state check had an else branch that unconditionally marked "General" active whenever the loop's current tab key didn't equal `$_GET['tab']` - which is true for every non-matching key, including "General" itself when a different tab (e.g. Add Ons) was actually selected. Result: General always showed as active alongside whichever tab you were really on.
- Replaces the per-key if/else with a single `$current_tab` computed once (defaulting to `general` only when no `tab` query var is present), compared directly against each key.
- Also removes a duplicate `$current_tab` computation further down the file that's now redundant.

## Test plan
- [ ] Visit the General tab and confirm only "General" is highlighted.
- [ ] Visit the Add Ons tab and confirm only "Add Ons" is highlighted (General should no longer also show active).
- [ ] Confirm saving settings from either tab still redirects back to the correct tab with the right one highlighted.

Generated with Claude Code
