### PR TITLE
fix: only set db version after migration completes

### DIFF
--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -438,8 +438,11 @@ class WLL_DB {
 			) );
 		}
 
-		// Update database version.
-		update_option( self::VERSION_OPTION, WLL_VER );
+		// Only set db version if no migration is needed.
+		// When posts need migration, the version is set after migrate_batch() completes.
+		if ( $posts_count === 0 ) {
+			update_option( self::VERSION_OPTION, WLL_VER );
+		}
 
 		/**
 		 * Fires after 1.3.0 upgrade completes.
@@ -574,6 +577,7 @@ class WLL_DB {
 			$status['status']    = 'complete';
 			$status['completed'] = current_time( 'mysql' );
 			update_option( 'wll_migration_status', $status );
+			update_option( self::VERSION_OPTION, self::$db_version );
 			return;
 		}
 
@@ -647,6 +651,7 @@ class WLL_DB {
 			$status['status']    = 'complete';
 			$status['completed'] = current_time( 'mysql' );
 			update_option( 'wll_migration_status', $status );
+			update_option( self::VERSION_OPTION, self::$db_version );
 		}
 
 		// Release lock after batch.

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -54,6 +54,49 @@ $wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migratio
 </script>
 <?php endif; ?>
 
+<?php
+// Check for orphaned CPT records after migration is marked complete.
+$wll_migration_status_check = get_option( 'wll_migration_status', array() );
+$wll_migration_complete = ! empty( $wll_migration_status_check ) && isset( $wll_migration_status_check['status'] ) && $wll_migration_status_check['status'] === 'complete';
+$wll_db_version_check = get_option( 'wll_db_version', '1.0.0' );
+
+if ( $wll_migration_complete && version_compare( $wll_db_version_check, '1.3.0', '>=' ) ) {
+	// Migration says it's done — check for orphaned CPT posts.
+	$wll_orphaned_count = 0;
+	$args = array(
+		'post_type'      => 'wll_records',
+		'post_status'    => 'any',
+		'posts_per_page' => 1,
+		'fields'         => 'ids',
+		'no_found_rows'  => false,
+	);
+	$wll_orphan_query = new WP_Query( $args );
+	$wll_orphaned_count = $wll_orphan_query->found_posts;
+
+	if ( $wll_orphaned_count > 0 ) :
+?>
+<div id="wll-orphaned-notice" class="notice notice-warning">
+	<p>
+		<strong><?php esc_html_e( 'When Last Login: Orphaned records detected', 'when-last-login' ); ?></strong><br>
+		<?php
+		printf(
+			/* translators: %d: number of orphaned records */
+			esc_html__( 'Migration is marked complete but %d CPT login records were found in the posts table. These were not migrated to the database tables and may need manual cleanup.', 'when-last-login' ),
+			$wll_orphaned_count
+		);
+		?>
+	</p>
+	<p>
+		<a href="<?php echo esc_url( add_query_arg( array( 'wll_cleanup_orphaned' => '1', 'wll_cleanup_nonce' => wp_create_nonce( 'wll_cleanup_orphaned' ) ), admin_url( 'admin.php?page=when-last-login-settings' ) ) ); ?>" class="button button-secondary">
+			<?php esc_html_e( 'Delete Orphaned Records', 'when-last-login' ); ?>
+		</a>
+	</p>
+</div>
+<?php
+	endif;
+}
+?>
+
 <div id="wll-setting-header">
 	<img src="<?php echo esc_url( WLL_PLUGIN . '/includes/images/whenlastlogin.png' ); ?>" width="300px" height="auto" style="margin-top:2%;"/><span style="position:relative;top:-15px;"><?php echo esc_html( 'v' . WLL_VER ); ?></span>
 </div>

--- a/includes/updates/upgrade-1.3.0.php
+++ b/includes/updates/upgrade-1.3.0.php
@@ -118,8 +118,11 @@ function wll_upgrade_1_3_0() {
 		) );
 	}
 
-	// Update database version.
-	update_option( 'wll_db_version', '1.3.0' );
+	// Only set db version if no migration is needed.
+	// When posts need migration, the version is set after wll_migrate_records_batch() completes.
+	if ( $posts_count === 0 ) {
+		update_option( 'wll_db_version', '1.3.0' );
+	}
 
 	// Release lock after upgrade completes.
 	delete_transient( 'wll_migration_lock' );
@@ -240,6 +243,7 @@ function wll_migrate_records_batch() {
 		$status['status']    = 'complete';
 		$status['completed'] = current_time( 'mysql' );
 		update_option( 'wll_migration_status', $status );
+		update_option( 'wll_db_version', '1.3.0' );
 		return;
 	}
 
@@ -282,6 +286,7 @@ function wll_migrate_records_batch() {
 		$status['status']    = 'complete';
 		$status['completed'] = current_time( 'mysql' );
 		update_option( 'wll_migration_status', $status );
+		update_option( 'wll_db_version', '1.3.0' );
 
 		// Clean up migrated posts from the posts table.
 		if ( class_exists( 'WLL_DB' ) ) {

--- a/when-last-login.php
+++ b/when-last-login.php
@@ -829,6 +829,33 @@ class When_Last_Login {
             wp_die( esc_html__( 'Invalid nonce', 'when-last-login' ) );
           }
         }
+
+        // Clean up orphaned CPT records after migration.
+        if ( isset( $_REQUEST['wll_cleanup_orphaned'] ) ) {
+          $nonce = isset( $_REQUEST['wll_cleanup_nonce'] ) ? sanitize_text_field( $_REQUEST['wll_cleanup_nonce'] ) : '';
+          if ( wp_verify_nonce( $nonce, 'wll_cleanup_orphaned' ) ) {
+            $deleted = $wpdb->query(
+              $wpdb->prepare(
+                "DELETE p, pm FROM {$wpdb->posts} p
+                 LEFT JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID
+                 WHERE p.post_type = %s",
+                'wll_records'
+              )
+            );
+            add_action( 'admin_notices', function() use ( $deleted ) {
+              printf(
+                '<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+                sprintf(
+                  /* translators: %d: number of orphaned records deleted */
+                  esc_html__( '%d orphaned CPT records cleaned up.', 'when-last-login' ),
+                  intval( $deleted )
+                )
+              );
+            } );
+          } else {
+            wp_die( esc_html__( 'Invalid nonce', 'when-last-login' ) );
+          }
+        }
     }
 
     public function wll_plugin_action_links( $links ) {


### PR DESCRIPTION
## Problem

Both `upgrade_1_3_0()` functions call `update_option('wll_db_version', '1.3.0')` immediately after scheduling the WP-Cron event — before any batch actually runs. If cron never fires (disabled, low traffic, crashed), the version is already set and `check_db_version()` never re-triggers the migration.

## Fix

Moves `update_option('wll_db_version')` out of the upgrade functions and into `migrate_batch()` — it now only fires when migration status reaches `'complete'`.

If no posts need migration, the version is set immediately (no migration needed).

## Orphaned records warning

Adds a warning notice on the WLL settings page when:
- Migration is marked `'complete'`
- DB version is `>= 1.3.0`
- But `wll_records` CPT posts still exist in the posts table

Includes a **Delete Orphaned Records** button that cleans up the leftover CPT posts and postmeta.

## Files changed

- `includes/class-wll-db.php` — `upgrade_1_3_0()` only sets version when no migration needed; `migrate_batch()` sets version on completion
- `includes/updates/upgrade-1.3.0.php` — same fix for the standalone upgrade script and `wll_migrate_records_batch()`
- `includes/settings.php` — orphaned records warning notice
- `when-last-login.php` — cleanup handler for orphaned CPT records