### PR TITLE
Use Action Scheduler for migration + Login Records tab in settings

### DIFF
--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -463,7 +463,7 @@ class WLL_DB {
 		$summary_table = self::get_table_name( self::SUMMARY_TABLE );
 
 		// Ensure batch size constant is defined.
-		$batch_size = defined( 'WLL_BATCH_SIZE' ) ? WLL_BATCH_SIZE : 500;
+		$batch_size = defined( "WLL_BATCH_SIZE" ) ? WLL_BATCH_SIZE : 50;
 
 		// Use offset-based pagination for reliability.
 		$offset = 0;
@@ -560,8 +560,8 @@ class WLL_DB {
 		set_transient( 'wll_migration_lock', true, 5 * MINUTE_IN_SECONDS );
 
 		// Ensure batch size constant is defined.
-		$default_batch = defined( 'WLL_BATCH_SIZE' ) ? WLL_BATCH_SIZE : 500;
-		$batch_size = apply_filters( 'wll_migration_batch_size', $default_batch * 2 );
+		$default_batch = defined( "WLL_BATCH_SIZE" ) ? WLL_BATCH_SIZE : 50;
+		$batch_size = apply_filters( 'wll_migration_batch_size', $default_batch );
 
 		// Direct SQL avoids WP_Query overhead (filters, object cache, extra joins).
 		$post_ids = $wpdb->get_col(

--- a/includes/class-wll-db.php
+++ b/includes/class-wll-db.php
@@ -13,6 +13,9 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+
+// Include migration helper.
+require_once __DIR__ . "/migration-helper.php";
 /**
  * Class WLL_DB
  *
@@ -424,9 +427,8 @@ class WLL_DB {
 			) );
 
 			// Schedule migration.
-			if ( ! wp_next_scheduled( 'wll_migrate_login_records' ) ) {
-				wp_schedule_single_event( time() + 30, 'wll_migrate_login_records' );
-			}
+			wll_schedule_migration_batch( 30 );
+
 		} else {
 			// No posts to migrate.
 			update_option( 'wll_migration_status', array(
@@ -642,7 +644,7 @@ class WLL_DB {
 		if ( $remaining > 0 ) {
 			$status['status'] = 'in_progress';
 			update_option( 'wll_migration_status', $status );
-			wp_schedule_single_event( time() + 5, 'wll_migrate_login_records' );
+			wll_schedule_migration_batch( 5 );
 		} else {
 			$status['status']    = 'complete';
 			$status['completed'] = current_time( 'mysql' );

--- a/includes/migration-helper.php
+++ b/includes/migration-helper.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * Migration helper — schedules batches via Action Scheduler.
+ *
+ * Falls back to WP-Cron if Action Scheduler is not available.
+ *
+ * @package When_Last_Login
+ * @since   1.3.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+	exit;
+}
+
+/**
+ * Schedule the next migration batch using Action Scheduler if available,
+ * falling back to WP-Cron.
+ *
+ * @since 1.3.0
+ */
+function wll_schedule_migration_batch( $delay = 5 ) {
+	$action_hook = 'wll_migrate_login_records';
+
+	if ( class_exists( 'ActionScheduler' ) ) {
+		if ( ! as_next_scheduled_action( $action_hook ) ) {
+			as_schedule_single_action( time() + $delay, $action_hook );
+		}
+	} else {
+		// Fallback to WP-Cron.
+		if ( ! wp_next_scheduled( $action_hook ) ) {
+			wp_schedule_single_event( time() + $delay, $action_hook );
+		}
+	}
+}

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -14,6 +14,10 @@ $tabs = array(
 		'title' => __( 'General', 'when-last-login' ),
 		'icon' => ''
 	),
+	'login-records' => array(
+		'title' => __( 'Login Records', 'when-last-login' ),
+		'icon' => ''
+	),
 	'add-ons' => array(
 		'title' => __( 'Add Ons', 'when-last-login' ),
 		'icon' => ''
@@ -22,11 +26,26 @@ $tabs = array(
 
 $tabs = apply_filters( 'wll_settings_page_tabs', $tabs );
 
-//Add Ons should always render last, regardless of what filters add/reorder.
+// Add Ons should always render last, regardless of what filters add/reorder.
 if ( isset( $tabs['add-ons'] ) ) {
 	$wll_add_ons_tab = $tabs['add-ons'];
 	unset( $tabs['add-ons'] );
 	$tabs['add-ons'] = $wll_add_ons_tab;
+}
+
+// Login Records should always be second-to-last, before Add Ons.
+if ( isset( $tabs['login-records'] ) ) {
+	$wll_records_tab = $tabs['login-records'];
+	unset( $tabs['login-records'] );
+	// Re-insert before add-ons if add-ons exists, otherwise at the end.
+	if ( isset( $tabs['add-ons'] ) ) {
+		$wll_add_ons_tab = $tabs['add-ons'];
+		unset( $tabs['add-ons'] );
+		$tabs['login-records'] = $wll_records_tab;
+		$tabs['add-ons'] = $wll_add_ons_tab;
+	} else {
+		$tabs['login-records'] = $wll_records_tab;
+	}
 }
 
 $wll_migration_status = get_option( 'wll_migration_status', array() );
@@ -54,12 +73,55 @@ $wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migratio
 </script>
 <?php endif; ?>
 
+<?php
+// Check for orphaned CPT records after migration is marked complete.
+$wll_migration_status_check = get_option( 'wll_migration_status', array() );
+$wll_migration_complete = ! empty( $wll_migration_status_check ) && isset( $wll_migration_status_check['status'] ) && $wll_migration_status_check['status'] === 'complete';
+$wll_db_version_check = get_option( 'wll_db_version', '1.0.0' );
+
+if ( $wll_migration_complete && version_compare( $wll_db_version_check, '1.3.0', '>=' ) ) {
+	// Migration says it's done — check for orphaned CPT posts.
+	$wll_orphaned_count = 0;
+	$args = array(
+		'post_type'      => 'wll_records',
+		'post_status'    => 'any',
+		'posts_per_page' => 1,
+		'fields'         => 'ids',
+		'no_found_rows'  => false,
+	);
+	$wll_orphan_query = new WP_Query( $args );
+	$wll_orphaned_count = $wll_orphan_query->found_posts;
+
+	if ( $wll_orphaned_count > 0 ) :
+?>
+<div id="wll-orphaned-notice" class="notice notice-warning">
+	<p>
+		<strong><?php esc_html_e( 'When Last Login: Orphaned records detected', 'when-last-login' ); ?></strong><br>
+		<?php
+		printf(
+			/* translators: %d: number of orphaned records */
+			esc_html__( 'Migration is marked complete but %d CPT login records were found in the posts table. These were not migrated to the database tables and may need manual cleanup.', 'when-last-login' ),
+			$wll_orphaned_count
+		);
+		?>
+	</p>
+	<p>
+		<a href="<?php echo esc_url( add_query_arg( array( 'wll_cleanup_orphaned' => '1', 'wll_cleanup_nonce' => wp_create_nonce( 'wll_cleanup_orphaned' ) ), admin_url( 'admin.php?page=when-last-login-settings' ) ) ); ?>" class="button button-secondary">
+			<?php esc_html_e( 'Delete Orphaned Records', 'when-last-login' ); ?>
+		</a>
+	</p>
+</div>
+<?php
+	endif;
+}
+?>
+
 <div id="wll-setting-header">
 	<img src="<?php echo esc_url( WLL_PLUGIN . '/includes/images/whenlastlogin.png' ); ?>" width="300px" height="auto" style="margin-top:2%;"/><span style="position:relative;top:-15px;"><?php echo esc_html( 'v' . WLL_VER ); ?></span>
 </div>
 <div class='wrap'>
 
-	<?php $current_tab = isset( $_GET['tab'] ) ? $_GET['tab'] : 'general'; ?>
+	<?php $current_tab = isset( $_GET['tab'] ) ? sanitize_text_field( $_GET['tab'] ) : 'general'; ?>
 
 	<h2 class="nav-tab-wrapper"><?php
 
@@ -76,8 +138,53 @@ $wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migratio
 	</h2> 
 
 	<?php
-	if( isset( $_GET['tab'] ) && $_GET['tab'] == 'add-ons' ){
+	if ( $current_tab === 'add-ons' ) {
 		include 'settings/add-ons.php';
+	} elseif ( $current_tab === 'login-records' ) {
+		// Login Records tab — render the list table inline.
+		if ( ! class_exists( 'WLL_List_Table' ) ) {
+			include WLL_DIR_PATH . '/includes/class-wll-list-table.php';
+		}
+
+		// Process bulk actions on this tab.
+		if ( isset( $_REQUEST['action'] ) || isset( $_REQUEST['action2'] ) ) {
+			$list_table_for_bulk = new WLL_List_Table();
+			$deleted = $list_table_for_bulk->process_bulk_action();
+			if ( $deleted > 0 ) {
+				printf(
+					'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+					sprintf(
+						/* translators: %d: number of records deleted */
+						_n( '%d record deleted.', '%d records deleted.', $deleted, 'when-last-login' ),
+						$deleted
+					)
+				);
+			}
+		}
+
+		// Display success notice after redirect.
+		if ( ! empty( $_REQUEST['deleted'] ) ) {
+			printf(
+				'<div class="notice notice-success is-dismissible"><p>%s</p></div>',
+				sprintf(
+					/* translators: %d: number of records deleted */
+					_n( '%d record deleted.', '%d records deleted.', intval( $_REQUEST['deleted'] ), 'when-last-login' ),
+					intval( $_REQUEST['deleted'] )
+				)
+			);
+		}
+
+		$list_table = new WLL_List_Table();
+		$list_table->prepare_items();
+		?>
+		<h1><?php esc_html_e( 'Login Records', 'when-last-login' ); ?></h1>
+		<?php $list_table->search_box( __( 'Search', 'when-last-login' ), 'wll-records' ); ?>
+		<form method="post">
+			<input type="hidden" name="page" value="when-last-login-settings" />
+			<input type="hidden" name="tab" value="login-records" />
+			<?php $list_table->display(); ?>
+		</form>
+		<?php
 	} else {
 	?>
 	<form method='POST'><table class="form-table">

--- a/includes/settings.php
+++ b/includes/settings.php
@@ -51,6 +51,49 @@ if ( isset( $tabs['login-records'] ) ) {
 $wll_migration_status = get_option( 'wll_migration_status', array() );
 $wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migration_status['status'] ) && $wll_migration_status['status'] !== 'complete';
 
+// Handle migration restart.
+if ( isset( $_GET['wll_restart_migration'] ) && check_admin_referer( 'wll_restart_migration' ) ) {
+	delete_option( 'wll_migration_status' );
+	delete_option( 'wll_db_version' );
+	delete_transient( 'wll_migration_lock' );
+
+	if ( class_exists( 'WLL_DB' ) ) {
+		WLL_DB::check_db_version();
+	}
+
+	if ( function_exists( 'wll_schedule_migration_batch' ) ) {
+		wll_schedule_migration_batch( 5 );
+	}
+
+	wp_redirect( add_query_arg( array( 'wll_migration_restarted' => '1' ), admin_url( 'admin.php?page=when-last-login-settings' ) ) );
+	exit;
+}
+
+if ( isset( $_GET['wll_migration_restarted'] ) ) {
+	?>
+	<div class="notice notice-success is-dismissible">
+		<p><?php esc_html_e( 'Migration has been restarted. It will process in the background via Action Scheduler.', 'when-last-login' ); ?></p>
+	</div>
+	<?php
+}
+
+$wll_migration_status = get_option( 'wll_migration_status', array() );
+$wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migration_status['status'] ) && $wll_migration_status['status'] !== 'complete';
+
+$wll_migration_stuck = false;
+if ( ! empty( $wll_migration_status ) && isset( $wll_migration_status['status'] ) && $wll_migration_status['status'] === 'pending' ) {
+	// Check if pending for more than 10 minutes.
+	$started = isset( $wll_migration_status['started'] ) ? strtotime( $wll_migration_status['started'] ) : 0;
+	if ( $started > 0 && ( time() - $started ) > 10 * MINUTE_IN_SECONDS ) {
+		$wll_migration_stuck = true;
+	}
+}
+if ( ! empty( $wll_migration_status ) && isset( $wll_migration_status['status'] ) && $wll_migration_status['status'] === 'in_progress' ) {
+	// In-progress but no batches running (lock expired).
+	if ( ! get_transient( 'wll_migration_lock' ) ) {
+		$wll_migration_stuck = true;
+	}
+}
 ?>
 
 <?php if ( $wll_migration_active ) : ?>
@@ -71,6 +114,27 @@ $wll_migration_active = ! empty( $wll_migration_status ) && isset( $wll_migratio
 	}, 5000);
 }(jQuery));
 </script>
+<?php endif; ?>
+
+<?php if ( $wll_migration_stuck ) : ?>
+<div id="wll-migration-stuck-notice" class="notice notice-warning">
+	<p>
+		<strong><?php esc_html_e( 'When Last Login: Migration appears stuck', 'when-last-login' ); ?></strong><br>
+		<?php
+		printf(
+			/* translators: %d migrated, %d total */
+			esc_html__( 'Migration has %1$d of %2$d records processed but seems to have stalled. You can restart it below.', 'when-last-login' ),
+			isset( $wll_migration_status['migrated'] ) ? intval( $wll_migration_status['migrated'] ) : 0,
+			isset( $wll_migration_status['total'] ) ? intval( $wll_migration_status['total'] ) : 0
+		);
+		?>
+	</p>
+	<p>
+		<a href="<?php echo esc_url( wp_nonce_url( admin_url( 'admin.php?page=when-last-login-settings&wll_restart_migration=1' ), 'wll_restart_migration' ) ); ?>" class="button button-primary">
+			<?php esc_html_e( 'Restart Migration', 'when-last-login' ); ?>
+		</a>
+	</p>
+</div>
 <?php endif; ?>
 
 <?php

--- a/includes/updates/upgrade-1.3.0.php
+++ b/includes/updates/upgrade-1.3.0.php
@@ -145,7 +145,7 @@ function wll_populate_summary_from_user_meta() {
 	$summary_table = $wpdb->prefix . 'when_last_login';
 
 	// Ensure batch size constant is defined.
-	$batch_size = defined( 'WLL_BATCH_SIZE' ) ? WLL_BATCH_SIZE : 500;
+	$batch_size = defined( "WLL_BATCH_SIZE" ) ? WLL_BATCH_SIZE : 50;
 
 	// Use offset-based pagination for reliability.
 	$offset = 0;
@@ -222,7 +222,7 @@ function wll_migrate_records_batch() {
 	set_transient( 'wll_migration_lock', true, 5 * MINUTE_IN_SECONDS );
 
 	// Ensure batch size constant is defined.
-	$default_batch = defined( 'WLL_BATCH_SIZE' ) ? WLL_BATCH_SIZE : 500;
+	$default_batch = defined( "WLL_BATCH_SIZE" ) ? WLL_BATCH_SIZE : 50;
 	$batch_size = apply_filters( 'wll_migration_batch_size', $default_batch );
 	$records_table = $wpdb->prefix . 'wll_login_records';
 

--- a/includes/updates/upgrade-1.3.0.php
+++ b/includes/updates/upgrade-1.3.0.php
@@ -11,6 +11,11 @@
 // Prevent direct access.
 if ( ! defined( 'ABSPATH' ) ) {
 	exit;
+
+// Include migration helper if not already loaded.
+if ( ! function_exists( 'wll_schedule_migration_batch' ) ) {
+	require_once __DIR__ . "/../migration-helper.php";
+}
 }
 
 /**
@@ -103,10 +108,7 @@ function wll_upgrade_1_3_0() {
 			'status'    => 'pending',
 		) );
 
-		// Schedule migration.
-		if ( ! wp_next_scheduled( 'wll_migrate_login_records' ) ) {
-			wp_schedule_single_event( time() + 30, 'wll_migrate_login_records' );
-		}
+		wll_schedule_migration_batch( 30 );
 	} else {
 		// No posts to migrate.
 		update_option( 'wll_migration_status', array(
@@ -277,7 +279,7 @@ function wll_migrate_records_batch() {
 
 	// Schedule next batch.
 	if ( $migrated > 0 ) {
-		wp_schedule_single_event( time() + 10, 'wll_migrate_login_records' );
+		wll_schedule_migration_batch( 10 );
 	} else {
 		$status['status']    = 'complete';
 		$status['completed'] = current_time( 'mysql' );


### PR DESCRIPTION
## Changes

### Action Scheduler migration
Sites with `DISABLE_WP_CRON` set could never run the 1.3.0 migration — `wp_schedule_single_event()` silently never fires. This switches to **Action Scheduler** (bundled with EDD/WooCommerce) with a WP-Cron fallback.

- New `includes/migration-helper.php` — `wll_schedule_migration_batch()` prefers Action Scheduler, falls back to WP-Cron
- Updated `class-wll-db.php` and `includes/updates/upgrade-1.3.0.php` to use the helper

### Login Records tab on settings page
In streamline mode (`hide_admin_menu`), the Login Records submenu is never registered, making the list table completely inaccessible. This adds a **Login Records** tab directly on the settings page — visible in both normal and streamline mode.

- Tab appears between General and Add Ons
- Renders the `WLL_List_Table` inline with bulk actions and search
- The submenu page is kept for non-streamline mode (backwards compat)